### PR TITLE
Code quality improvements + macOS VoiceOver Braille + CI release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,120 @@
+name: Build and Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  build-windows:
+    name: Build Windows (${{ matrix.preset }})
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        preset: [windows-x64, windows-x86, windows-arm64]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Inno Setup
+        run: choco install innosetup --no-progress -y
+
+      - name: Configure (${{ matrix.preset }})
+        run: cmake --preset ${{ matrix.preset }}
+
+      - name: Build launcher (${{ matrix.preset }})
+        run: cmake --build --preset ${{ matrix.preset }} --target EltenLauncher --config Release
+
+      - name: Upload launcher artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: launcher-${{ matrix.preset }}
+          path: build/release/windows/
+
+  build-windows-installer:
+    name: Build Windows Installer
+    runs-on: windows-latest
+    needs: build-windows
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Inno Setup
+        run: choco install innosetup --no-progress -y
+
+      - name: Download x64 launcher
+        uses: actions/download-artifact@v4
+        with:
+          name: launcher-windows-x64
+          path: build/release/windows/
+
+      - name: Configure (windows-x64 for installer)
+        run: cmake --preset windows-x64
+
+      - name: Build installer
+        run: cmake --build --preset windows-x64 --target EltenPkg --config Release
+
+      - name: Upload Windows installer
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-installer
+          path: dist/windows/EltenSetup.exe
+
+  build-macos:
+    name: Build macOS (arm64)
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install build dependencies
+        run: brew install cmake
+
+      - name: Configure (osx-arm64)
+        run: cmake --preset osx-arm64
+
+      - name: Build launcher (osx-arm64)
+        run: cmake --build --preset osx-arm64 --target EltenLauncher
+
+      - name: Build macOS package
+        run: cmake --build --preset osx-arm64 --target EltenPkg
+
+      - name: Upload macOS package
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-package
+          path: dist/osx/Elten.pkg
+
+  release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    needs: [build-windows-installer, build-macos]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download Windows installer
+        uses: actions/download-artifact@v4
+        with:
+          name: windows-installer
+          path: artifacts/
+
+      - name: Download macOS package
+        uses: actions/download-artifact@v4
+        with:
+          name: macos-package
+          path: artifacts/
+
+      - name: Extract version from tag
+        id: version
+        run: echo "version=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: Elten ${{ steps.version.outputs.version }}
+          draft: false
+          prerelease: ${{ contains(github.ref, 'beta') || contains(github.ref, 'alpha') || contains(github.ref, 'rc') }}
+          generate_release_notes: true
+          files: |
+            artifacts/EltenSetup.exe
+            artifacts/Elten.pkg

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ if(CMAKE_GENERATOR MATCHES "Visual Studio")
 endif()
 
 if(APPLE AND NOT DEFINED CMAKE_OSX_DEPLOYMENT_TARGET)
-  set(CMAKE_OSX_DEPLOYMENT_TARGET "26.0" CACHE STRING "Minimum macOS deployment target")
+  set(CMAKE_OSX_DEPLOYMENT_TARGET "13.0" CACHE STRING "Minimum macOS deployment target")
 endif()
 
 project(EltenLauncher LANGUAGES CXX)

--- a/filelist
+++ b/filelist
@@ -71,6 +71,7 @@ src/scenes/log.rb
 src/eapi/speechoutput.rb
 src/platforms/windows/eapi/nvda.rb :windows
 src/platforms/osx/eapi/speech.rb :osx
+src/platforms/osx/eapi/voiceover.rb :osx
 src/scenes/sounds.rb
 src/eapi/opus.rb
 src/eapi/recorder.rb

--- a/src/eapi/__eapi.rb
+++ b/src/eapi/__eapi.rb
@@ -253,7 +253,7 @@ module LocalConfig
 LOCache[k] = v
           end
           def save
-            for k in LCCache.keys
+            LCCache.keys.each do |k|
               v=LCCache[k]
               writeconfig("local", k, v) if v!=LOCache[k]
 LOCache[k] = v
@@ -292,9 +292,9 @@ rowNum = [-1, 0, 0, 1]
 colNum = [0, -1, 1, 0]
 return nil if(mat[x][y]==false or mat[ox][oy]==false)
 visited=[]
-for i in 0...mat.size
+(0...mat.size).each do |i|
 visited[i]=[]
-for j in 0...mat[i].size
+(0...mat[i].size).each do |j|
 visited[i][j]=false
 end
 end
@@ -306,7 +306,7 @@ if(curr[0][0] == ox && curr[0][1] == oy)
 return curr[1]
 end
 q.delete_at(0)
-for i in 0...4
+(0...4).each do |i|
   row = curr[0][0] + rowNum[i]
 col = curr[0][1] + colNum[i]
 if row>=0 && col>=0 && row<mat.size && col<mat[row].size && mat[row][col]==true && !visited[row][col]
@@ -411,13 +411,13 @@ end
                   Bass.setdevice(-1)
                 else
     sc=Bass.soundcards
-  for i in 0...sc.size
+  (0...sc.size).each do |i|
     if sc[i].name==Configuration.soundcard
     Bass.setdevice(i)
     end
   end
     devices=defined?(Sapi) ? Sapi.devices : []
-    for i in 0...devices.size
+    (0...devices.size).each do |i|
             if Configuration.soundcard==devices[i]
                 Sapi.set_device(i)
         end
@@ -426,7 +426,7 @@ end
 Configuration.microphone = readconfig("SoundCard", "Microphone", "")
   s=false
   mc=Bass.microphones
-  for i in 0...mc.size
+  (0...mc.size).each do |i|
     if mc[i].name==Configuration.microphone
           Bass.setrecorddevice(i)
     s=true
@@ -619,7 +619,7 @@ end
 
   def save
     c=current
-    for entry in c.keys
+    c.keys.each do |entry|
       del=(c[entry]['totime']!=0 && c[entry]['totime']<=Time.now.to_i) || c[entry]['lastaccess']<Time.now.to_i-86400*30
       c.delete(entry) if del
       end

--- a/src/eapi/bass.rb
+++ b/src/eapi/bass.rb
@@ -1,4 +1,4 @@
-﻿# A part of Elten - EltenLink / Elten Network desktop client.
+# A part of Elten - EltenLink / Elten Network desktop client.
 # Copyright (C) 2014-2026 Dawid Pieper
 # Elten is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 3. 
 # Elten is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details. 
@@ -46,7 +46,7 @@ module EltenBassStructs
     def bass_channel_info_values(buffer)
       filename_offset = POINTER_SIZE == 8 ? 32 : 28
       values = []
-      for i in 0...7
+      (0...7).each do |i|
         values.push(dword_value(buffer, i * 4))
       end
       values.push(pointer_value(buffer, filename_offset))
@@ -531,7 +531,7 @@ return if @init==true
       raise(error_name)
     end
     plugins = ["bassopus", "bassflac", "bassmidi", "basswebm", "basswma", "bass_aac", "bass_ac3", "bass_spx", "basshls", "bassalac"]
-        for pl in plugins
+        plugins.each do |pl|
               Log.debug("Loading Bass plugin #{pl}")
           plugin_path = EltenRuntimePaths.absolute_library_file(pl)
           if BASS_PluginLoad.call(plugin_path, 0) == 0
@@ -656,7 +656,7 @@ class VST
   def parameters
     cnt = BASS_VST_GetParamCount.call(@vst)
     params=[]
-    for i in 0...cnt
+    (0...cnt).each do |i|
       params.push(Parameter.new(@vst, i))
     end
     params
@@ -721,7 +721,7 @@ class VST
   def programs
     count = BASS_VST_GetProgramCount.call(@vst)
     programs=[]
-    for i in 0...count
+    (0...count).each do |i|
       ptr = BASS_VST_GetProgramName.call(@vst, i)
       programs[i]=Bass.c_string(ptr).force_encoding("UTF-8")
     end

--- a/src/eapi/common.rb
+++ b/src/eapi/common.rb
@@ -155,7 +155,7 @@ loop_update
             form.focus
           }
           menu.submenu(p_("EAPI_Common", "Last codes")) { |m|
-            for c in container.codes
+            container.codes.each do |c|
               menu.option(c[0...100], c) { |c|
                 form.fields[0].set_text(c)
                 form.focus
@@ -184,7 +184,7 @@ loop_update
           rescue Exception
             plc = ""
             if $@.is_a?(Array)
-              for e in $@
+              $@.each do |e|
                 if e != nil
                   plc += e + "\n" if e != nil and e[0..6] != "Section"
                 end
@@ -274,7 +274,7 @@ else
   sel.push("")
   end
     if $usermenuextra.is_a?(Hash) and Session.name!="guest"
-      for k in $usermenuextra.keys
+      $usermenuextra.keys.each do |k|
     sel.push(k)
     end
     end
@@ -734,7 +734,7 @@ if default_keyboard && EltenWindow.character_input_supported?
   keybd=keybd.map{|k|((k)?(255):(0))}.pack("C*") if keybd.is_a?(Array)
   akey=akey.unpack("c*").map{|k|k<0} if !akey.is_a?(Array)
     ret=""
-          for i in 32..255
+          (32..255).each do |i|
     if akey[i]
       re = EltenKeyboard.translate_virtual_key(i, keybd)
 

--- a/src/eapi/conference.rb
+++ b/src/eapi/conference.rb
@@ -404,7 +404,7 @@ def self.source_for(stream, source, may_stream=false)
   if !stream.is_a?(Numeric)
     s=@@core.sources.find{|src|src.is_a?(Core::StreamSourceFile)}
     return s if s!=nil
-    for st in @@core.outstreams
+    @@core.outstreams.each do |st|
       s=st.sources.find{|src|src.is_a?(Core::StreamSourceFile)}
       return s if s!=nil
     end
@@ -824,7 +824,7 @@ def self.volume(user)
 def self.volumes
   return {} if @@volumes==nil
   vls={}
-  for u in @@volumes.keys
+  @@volumes.keys.each do |u|
     vls[u] = ChannelUserVolume.new(u, @@volumes[u][0], @@volumes[u][1], @@volumes[u][2], @@volumes[u][3])
     end
   return vls
@@ -862,7 +862,7 @@ def self.waiting_channel_id
   def self.channels
     channels=[]
   if @@channels.is_a?(Array)
-    for cha in @@channels
+    @@channels.each do |cha|
             ch=Channel.new
       ch.id=cha['id'].to_i
       ch.name=cha['name'].to_s
@@ -879,7 +879,7 @@ def self.waiting_channel_id
       ch.spatialization=cha['spatialization']
       ch.creator=cha['creator']
       ch.groupid=cha['groupid'].to_i
-      for u in cha['users']
+      cha['users'].each do |u|
         ch.users.push(ChannelUser.new(u['id'], u['name']))
       end
       ch.administrators=cha['administrators']||[]
@@ -1059,7 +1059,7 @@ end
                         def self.setmystreams(str)
                                                 st=JSON.load(str)
                                                 @@mystreams=Streams.new
-                                                for s in st['sources']
+                                                st['sources'].each do |s|
                                                   so=Source.new
                                                   so.name=s['name']
                                                   so.volume=s['volume']
@@ -1067,14 +1067,14 @@ end
                                                   so.toggleable=s['toggleable']
                                                   @@mystreams.sources.push(so)
                                                 end
-for s in st['streams']
+st['streams'].each do |s|
   str=Stream.new
   str.name=s['name']
   str.volume=s['volume']
   str.x=s['x']
   str.y=s['y']
   str.locally_muted=s['locally_muted']
-  for o in s['sources']
+  s['sources'].each do |o|
     so=Source.new
     so.name=o['name']
     so.volume=o['volume']
@@ -1205,7 +1205,7 @@ def self.on(hook, &block)
                           @@hooks.delete(hk)
                           end
                         def self.trigger(hook)
-                          for hk in @@hooks
+                          @@hooks.each do |hk|
                             hk.block.call if hk.hook==hook
                             end
                           end

--- a/src/eapi/conferencecore.rb
+++ b/src/eapi/conferencecore.rb
@@ -295,7 +295,7 @@ t=@preprocessor
 end
 return if t==nil
 @vst_target = t
-for i in 0...@vsts.size
+(0...@vsts.size).each do |i|
 v=Bass::VST.new(@vsts[i].file, t, @vsts[i].priority)
 v.import(:bank, @vsts[i].export(:bank))
 @vsts[i].free
@@ -345,7 +345,7 @@ vsts_reprioritize
 end
 def vsts_reprioritize
 @vst_lastpriority = 2**31
-for i in 0...@vsts.size
+(0...@vsts.size).each do |i|
 @vst_lastpriority -= 1
 @vsts[i].priority=@vst_lastpriority
 end
@@ -740,7 +740,7 @@ t=@preprocessor
 end
 return if t==nil
 @vst_target = t
-for i in 0...@vsts.size
+(0...@vsts.size).each do |i|
 v=Bass::VST.new(@vsts[i].file, t, @vsts[i].priority)
 v.import(:bank, @vsts[i].export(:bank))
 @vsts[i].free
@@ -790,7 +790,7 @@ vsts_reprioritize
 end
 def vsts_reprioritize
 @vst_lastpriority = 2**31
-for i in 0...@vsts.size
+(0...@vsts.size).each do |i|
 @vst_lastpriority -= 1
 @vsts[i].priority=@vst_lastpriority
 end
@@ -1197,10 +1197,10 @@ if r==0
 r=Bass::BASS_RecordStart.call(0, 0, 0, 0, 0)
 end
 if r==0
-for freq in [192000, 176400, 96000, 88200, 64000, 48000, 44100, 32000, 24000, 22050, 16000, 8000]
+[192000, 176400, 96000, 88200, 64000, 48000, 44100, 32000, 24000, 22050, 16000, 8000].each do |freq|
 r=Bass::BASS_RecordStart.call(freq, 0, 256, 0, 0)
 break if r!=0
-for ch in (1..16).to_a.reverse
+(1..16).to_a.reverse.each do |ch|
 r=Bass::BASS_RecordStart.call(freq, ch, 256, 0, 0)
 break if r!=0
 r=Bass::BASS_RecordStart.call(freq, ch, 0, 0, 0)
@@ -1453,7 +1453,7 @@ def filestream(ind=-1)
 if ind==-1
 r=@sources.find{|s|s.is_a?(StreamSourceFile)}
 return r if r!=nil
-for s in @outstreams
+@outstreams.each do |s|
 r=s.sources.find{|s|s.is_a?(StreamSourceFile)}
 return r if r!=nil
 end
@@ -1502,10 +1502,10 @@ Dir.mkdir(dir+"/streams") if !FileTest.exist?(dir+"/streams")
 @fullsave_chat.write("time,transmitter,username,message\n")
 @fullsave_chat.write("#{Time.now.strftime("%Y-%m-%d %H:%M:%S")},0,,\"Begin of save\"\n")
 @fullsave_myrec=$vorbisrecorderinit.call(unicode(dir+"/myrec.ogg"), 48000, 2, 500000)
-for t in @transmitters.keys
+@transmitters.keys.each do |t|
 @transmitters[t].begin_save(dir, t, @fullsave_time)
 end
-for s in @streams.keys
+@streams.keys.each do |s|
 @streams[s].begin_save(dir, s, @fullsave_time)
 end
 begin_save(dir+"/mixed.ogg")
@@ -1543,10 +1543,10 @@ end
 if @fullsave_dir!=nil
 @fullsave_dir=nil
 @fullsave_time=nil
-for t in @transmitters.values
+@transmitters.values.each do |t|
 t.end_save
 end
-for s in @streams.values
+@streams.values.each do |s|
 s.end_save
 end
 end
@@ -1607,7 +1607,7 @@ end
 end
 def remove_card
 log(-1, "Conference: unmixing cards")
-for s in @sources.find_all{|s|s.is_a?(StreamSourceCard)}.dup
+@sources.find_all{|s|s.is_a?(StreamSourceCard)}.dup.each do |s|
 s.free
 @sources.delete(s)
 end
@@ -1660,7 +1660,7 @@ end
 def remove_stream(hook=true)
 log(-1, "Conference: removing file stream")
 @stream_mutex.synchronize {
-for s in @sources.find_all{|s|s.is_a?(StreamSourceFile)}.dup
+@sources.find_all{|s|s.is_a?(StreamSourceFile)}.dup.each do |s|
 s.free
 @sources.delete(s)
 end
@@ -1855,7 +1855,7 @@ volume*=300 if volume>300
 volume=10 if volume<10
 v=[volume, muted, chat_muted, streams_muted]
 @volumes[user]=v
-for t in @transmitters.values
+@transmitters.values.each do |t|
 t.setvolume(v) if t.username==user
 end
 if muted
@@ -2055,16 +2055,16 @@ calling_stop
 begin
 @recorder_thread.exit if @recorder_thread!=nil
 if subs
-for t in @transmitters.values
+@transmitters.values.each do |t|
 t.free
 end
-for s in @streams.values
+@streams.values.each do |s|
 s.free
 end
-for s in @sources
+@sources.each do |s|
 s.free
 end
-for o in @objects.keys
+@objects.keys.each do |o|
 @objects[o].free
 end
 end
@@ -2080,7 +2080,7 @@ Bass::BASS_StreamFree.call(@recordstream)
 Bass::BASS_StreamFree.call(@outstreams_mixer)
 Bass::BASS_StreamFree.call(@channel_mixer)
 Bass::BASS_StreamFree.call(@whisper_mixer)
-for s in @outstreams
+@outstreams.each do |s|
 s.free
 @outstreams.delete(s)
 end
@@ -2159,7 +2159,7 @@ buf=buf.byteslice(lastsp+1..-1)
 end
 messages.push(buf) if buf.bytesize>0
 end
-for i in 0...messages.size
+(0...messages.size).each do |i|
 @voip.send(2, messages[i], (i==messages.size-1)?(0):(1))
 end
 end
@@ -2200,7 +2200,7 @@ return 0 if @framesize==0
 losses=0
 all=0
 fs=(5000/@framesize.to_f).to_i
-for t in @transmitters.values
+@transmitters.values.each do |t|
 if t.losses.size>fs
 all+=fs
 losses=t.losses[-fs..-1].sum
@@ -2292,7 +2292,7 @@ end
 def vsts_reprioritize(userid=0)
 if userid==0
 @vst_lastpriority = 2**31
-for i in 0...@vsts.size
+(0...@vsts.size).each do |i|
 @vst_lastpriority -= 1
 @vsts[i].priority=@vst_lastpriority
 end
@@ -2328,7 +2328,7 @@ def userid
 end
 private
 def position_changed
-for s in @outstreams
+@outstreams.each do |s|
 s.set_user_position(@position.x, @position.y, @position.dir)
 end
 if is_muted
@@ -2405,10 +2405,10 @@ if r==0
 r=Bass::BASS_RecordStart.call(0, 0, 0, 0, 0)
 end
 if r==0
-for freq in [48000, 44100, 96000, 88200, 192000, 176400, 384000, 64000, 32000, 24000, 22050, 16000, 8000]
+[48000, 44100, 96000, 88200, 192000, 176400, 384000, 64000, 32000, 24000, 22050, 16000, 8000].each do |freq|
 r=Bass::BASS_RecordStart.call(freq, 0, 256, 0, 0)
 break if r!=0
-for ch in (1..16).to_a.reverse
+(1..16).to_a.reverse.each do |ch|
 r=Bass::BASS_RecordStart.call(freq, ch, 256, 0, 0)
 break if r!=0
 r=Bass::BASS_RecordStart.call(freq, ch, 0, 0, 0)
@@ -2446,7 +2446,7 @@ pos_y=p2
 pos_x=-1 if pos_x<1||pos_x>255
 pos_y=-1 if pos_y<1||pos_y>255
 frame_id = p3*256+p4
-for s in @streams.values
+@streams.values.each do |s|
 if s.userid==userid
 s.set_user_position(pos_x, pos_y)
 end
@@ -2529,7 +2529,7 @@ pos_x=p1
 pos_y=p2
 pos_x=-1 if pos_x<1||pos_x>255
 pos_y=-1 if pos_y<1||pos_y>255
-for s in @streams.values
+@streams.values.each do |s|
 if s.userid==userid
 s.set_user_position(pos_x, pos_y)
 end
@@ -2634,7 +2634,7 @@ Bass::BASS_StreamFree.call(@output_stream) if @output_stream!=0
 Bass::BASS_Mixer_StreamAddChannel.call(@output, @output_mixer, 0)
 Bass::BASS_Mixer_StreamAddChannel.call(@saver, @output_stream, 0)
 @channels=params['channel']['channels']
-for t in @transmitters.keys
+@transmitters.keys.each do |t|
 @transmitters[t].free
 @transmitters.delete(t)
 end
@@ -2646,7 +2646,7 @@ n=params['channel']['users'].size
 c = params['channel']['users'].find_index{|u|u['id']==@voip.uid}
 c=0 if c==nil
 da = 2.0*Math::PI/n
-for i in 0...params['channel']['users'].size
+(0...params['channel']['users'].size).each do |i|
 u = params['channel']['users'][i]
 uid=u['id']
 a = ((n-c+i)%n) * da
@@ -2684,7 +2684,7 @@ end
 end
 @channel_hooks.each{|h|h.call(params['channel'])}
 @volumes_hooks.each{|h|h.call(@volumes)}
-for t in @transmitters.keys
+@transmitters.keys.each do |t|
 if !upusers.include?(t)
 @whisper=0 if @whisper==t
 @user_hooks.each{|h|h.call(false, @transmitters[t].username, t)} if frs==false
@@ -2694,7 +2694,7 @@ log(-1, "Conference: unregistering transmitter #{t}")
 end
 end
 upobjects=[]
-for o in params['channel']['objects']
+params['channel']['objects'].each do |o|
 oid=o['id']
 upobjects.push(oid)
 if @objects.include?(oid)
@@ -2707,19 +2707,19 @@ log(-1, "Conference: registering new object #{o['name']}")
 @objects[oid].set_mixer(@channel_mixer)
 end
 end
-for o in @objects.keys
+@objects.keys.each do |o|
 if !upobjects.include?(o)
 log(-1, "Conference: unregistering object #{o}")
 @objects[o].free
 @objects.delete(o)
 end
 end
-for s in @outstreams
+@outstreams.each do |s|
 s.set_mixer(@channel_mixer)
 end
 if params['channel']['streams'].is_a?(Array)
 upstreams=[]
-for s in params['channel']['streams']
+params['channel']['streams'].each do |s|
 sid=s['id']
 upstreams.push(sid)
 if @streams.include?(sid)
@@ -2735,7 +2735,7 @@ username=@transmitters[s['user']].username if @transmitters[s['user']]!=nil
 @streams[sid].set_user_position(@transmitters[s['user']].transmitter_x, @transmitters[s['user']].transmitter_y) if @transmitters[s['user']]!=nil and @transmitters[s['user']].transmitter_x>0
 end
 end
-for s in @streams.keys
+@streams.keys.each do |s|
 if !upstreams.include?(s)
 log(-1, "Conference: unregistering stream #{s}")
 @voip.streamid_unmute(s)
@@ -2748,7 +2748,7 @@ end
 end
 if params['channel']['speakers'].is_a?(Array)
 upspeakers=[]
-for userid in params['channel']['speakers']
+params['channel']['speakers'].each do |userid|
 upspeakers.push(userid)
 if !@speakers.include?(userid)
 username=""
@@ -2757,7 +2757,7 @@ username=@transmitters[userid].username if @transmitters[userid]!=nil
 @speaker_hooks.each{|h|h.call(1, username, userid)} if userid==@voip.uid
 end
 end
-for s in @speakers.keys
+@speakers.keys.each do |s|
 username,userid=@speakers[s]
 if !upspeakers.include?(userid)
 @speaker_hooks.each{|h|h.call(0, username, userid)} if userid==@voip.uid
@@ -2767,7 +2767,7 @@ end
 end
 if params['channel']['waiting_users'].is_a?(Array) 
 upwaiting=[]
-for w in params['channel']['waiting_users']
+params['channel']['waiting_users'].each do |w|
 upwaiting.push(w['id'])
 if !@waiting_users.map{|u|u.id}.include?(w['id'])
 wu=WaitingUser.new
@@ -2778,7 +2778,7 @@ wu.name=w['name']
 end
 end
 todel=[]
-for w in @waiting_users
+@waiting_users.each do |w|
 if !upwaiting.include?(w.id)
 todel.push(w)
 @waitinguser_hooks.each{|h|h.call(false, w.name, w.id)}
@@ -2808,7 +2808,7 @@ if @pushtotalk==true
 return true if @pushtotalk_keys.size==0
 suc=true
 $neededkeys = @pushtotalk_keys
-for k in @pushtotalk_keys
+@pushtotalk_keys.each do |k|
 if $conference_key_state[k]==false
 suc=false
 break
@@ -2949,7 +2949,7 @@ audio.clear
 end
 }
 end
-for s in @outstreams
+@outstreams.each do |s|
 if s.encoder!=nil && !s.encoder.closed? && @bitrate!=0 && @stream_bitrate!=0
 mb=maxBytes
 mb*=(s.channels.to_f/@channels)

--- a/src/eapi/controls.rb
+++ b/src/eapi/controls.rb
@@ -23,7 +23,7 @@ module EltenAPI
 0xBC=>"comma", 0xBD=>"minus", 0xBE=>"period",
 0x25=>"left", 0x26=>"up", 0x27=>"right", 0x28=>"down"
 }
-     for e in ks.keys
+     ks.keys.each do |e|
        k.push([("key_"+ks[e]).to_sym, ks[e].to_sym]) if key_pressed?(e)
        k.push([("keyr_"+ks[e]).to_sym, ks[e].to_sym]) if key_held?(e)
        k.push([("keyup_"+ks[e]).to_sym, ks[e].to_sym]) if key_released?(e)
@@ -813,7 +813,7 @@ espeech(p_("EAPI_Form", "End of line"))
                                     end
           end
           if last!=@vindex
-          for e in @elements
+          @elements.each do |e|
             if last<e.from || last>e.to
               if @vindex>=e.from && @vindex<=e.to
                 d=e.description
@@ -847,7 +847,7 @@ def setformatting(type, params=nil)
                               if range!=nil
                                 from,to=range
                                 s=false
-                                for e in @elements
+                                @elements.each do |e|
                                   next if e.type!=type
                                   s=true if e.from>=from && e.from<=to
                                   s=true if e.to>=from && e.to<=to
@@ -856,7 +856,7 @@ def setformatting(type, params=nil)
                                 if s==true
                                   del=[]
                                   ins=[]
-                                  for e in @elements
+                                  @elements.each do |e|
                                     next if e.type!=type
                                     if e.from>=from && e.to<=to
                                       del.push(e)
@@ -917,14 +917,14 @@ def context(menu, submenu=false)
     end
     }
     m.submenu(p_("EAPI_Form", "Heading")) {|n|
-        for i in 1..6
+        (1..6).each do |i|
       n.option(p_("EAPI_Form", "Heading level %{level}")%{:level=>i}, i, i.to_s) {|level|
       if requires_premiumpackage("scribe")
       a=line_beginning(@vindex, true)
       b=line_ending(@vindex, true)
       del=[]
       s=false
-      for e in @elements
+      @elements.each do |e|
         if e.type==Element::Header && ((e.from>=a && e.from<=b) || (e.to>=a && e.to<=b))
           s=true if e.param==level
           del.push(e)
@@ -1007,7 +1007,7 @@ eredo
   }
   end
   menu.submenu(p_("EAPI_Form", "Load last text")) {|m|
-  for e in @@lastedits
+  @@lastedits.each do |e|
     next if e==self
     t=(e.header+": "+e.text)[0...200]
     m.option(t, e) {|e|
@@ -1030,7 +1030,7 @@ search
   translator(get_check_or_all)
   end
   }
-  for a in @@customactions
+  @@customactions.each do |a|
       menu.option(a[0]) {
     a[1].call(self)
   }
@@ -1048,7 +1048,7 @@ def espellcheck
   langs=[]
   langnames=[]
   lnindex=0
-  for lk in Lists.langs.keys
+  Lists.langs.keys.each do |lk|
     next if !sclangs.map{|l|l[0..1].downcase}.include?(lk[0..1].downcase)
     langs.push(lk)
     l=Lists.langs[lk]
@@ -1066,7 +1066,7 @@ def espellcheck
   form.fields[1...-2]=[]
   form.show_all
   errors=SpellCheck.check(langs[lst_languages.index], @text)
-  for error in errors
+  errors.each do |error|
         phr=splt[error.index...(error.index+error.length)]
         frgb=-1
         frge=0
@@ -1074,7 +1074,7 @@ def espellcheck
         pfrgb=0 if pfrgb<0
         pfrge=error.index+error.length+60
         pfrge=splt.length-1 if pfrge>=splt.length
-                for i in pfrgb..pfrge
+                pfrgb..pfrge.each do |i|
           if i<error.index&& frgb==-1
           frgb=i if splt[i-1..i-1]==" " || i==0
           elsif i>error.index+error.length
@@ -1084,7 +1084,7 @@ def espellcheck
             frg=splt[frgb..frge]||""
     letphr="("+phr.split("").join(", ")+")"
     options=[]
-    for sug in error.suggestions
+    error.suggestions.each do |sug|
       letsug="("+sug.split("").join(", ")+")"
       opt=sug+" "+letsug
       options.push(opt)
@@ -1093,7 +1093,7 @@ def espellcheck
     lst = ListBox.new([p_("EAPI_Form", "Ignore")]+options+[p_("EAPI_Form", "Use custom text")], header: label)
 edt = EditBox.new(label, type: 0, text: phr)
 lst.on(:move) {
-for i in 0...errors.size
+(0...errors.size).each do |i|
   l=form.fields[1+i*2]
   e=form.fields[1+i*2+1]
   next if l==nil || e==nil
@@ -1115,7 +1115,7 @@ for i in 0...errors.size
   btn_replace.on(:press) {
   chindex=0
   repls=0
-  for i in 0...errors.size
+  (0...errors.size).each do |i|
     if form.fields[1+i*2].index>0
       corr=""
       if form.fields[1+i*2].index<form.fields[1+i*2].options.size-1
@@ -1276,7 +1276,7 @@ l=((((index>3000?index-3000:0) ... index).find_all { |i| text_char(i)=="\n"}[-1]
   r=((index ... (index<text_len-3000?index+3000:text_len)).find_all { |i| text_char(i)=="\n"}[0])||text_len    
   ls=get_vlines(l,r, absolute)
   ind=l
-  for n in ls
+  ls.each do |n|
     ind=n if n<=index
   end
       return ind
@@ -1288,7 +1288,7 @@ def line_ending(index=@vindex, absolute=false)
   r=((index ... (index<text_len-3000?index+3000:text_len)).find_all { |i| text_char(i)=="\n"}[0])||text_len
         ls=get_vlines(l,r, absolute)
       ln=0
-    for i in 0...ls.size-1
+    (0...ls.size-1).each do |i|
     ln=i if ls[i]<=index
   end
   ind=ls[ln+1]-1            
@@ -1301,9 +1301,9 @@ def line_ending(index=@vindex, absolute=false)
 def get_vlines(l,r, absolute=false)
     return [l,r+1] if r-l<120 or (@flags&Flags::MultiLine)==0 or (@flags&Flags::DisableLineWrapping)>0 or Configuration.linewrapping==0 or absolute==true
   ls=[l]
-    for c in l...r
+    l...r.each do |c|
            if text_char(c)==" " and c-ls[-1]>120 and c!=r-1
-                        for oc in c..r
+                        c..r.each do |oc|
 if text_char(oc)!=" "
               ls.push(oc)
               break if oc>=r
@@ -1321,7 +1321,7 @@ if text_char(oc)!=" "
         ns=(0...text_len).find_all {|c| text_char(c)=="\n"}
         ns.push(text_len-1)
         lines=[]
-        for i in 0..ns.size-1
+        (0..ns.size-1).each do |i|
                     prior=-1
           prior=ns[i-1] if i>0
           lines+=get_vlines(prior+1,ns[i])
@@ -1373,7 +1373,7 @@ def get_check_or_all
       return
     end
     if @permitted_characters.size>0
-      for c in text.split("")
+      text.split("").each do |c|
         if !@permitted_characters.include?(c)
                 play_sound("border")
       return
@@ -1399,7 +1399,7 @@ def get_check_or_all
 @undo.delete_at(0) if @undo.size>100
 @redo=[] if toundo==true
     applied=[]
-        for e in @elements
+        @elements.each do |e|
       i=@formats.find_index(e.type)
       if e.from<=index && e.to>=index && (text!="\n" || i!=nil)
         play_sound('signal')
@@ -1414,7 +1414,7 @@ def get_check_or_all
         e.to+=text_length
         end
       end
-    for i in 0...@formats.size
+    (0...@formats.size).each do |i|
       if applied[i]!=true
         e=Element.new(index, index, @formats[i])
         @elements.push(e)
@@ -1439,7 +1439,7 @@ deleted_length=character_length(deleted_text)
 @redo=[] if toundo==true
 @undo.delete_at(0) if @undo.size>100
 del=[]
-for e in @elements
+@elements.each do |e|
   if e.to<from
     next
   elsif e.from>to
@@ -1669,7 +1669,7 @@ def html_append_block_break(tag, output, before:)
 end
                 def find_element(type=0,flags=nil,revdir=false,index=@index)
                   e=Element.new(text_len,-1,0)
-                  for el in @elements
+                  @elements.each do |el|
                     e=el if (((!type.is_a?(Array) && el.type==type) || (type.is_a?(Array) && type.include?(el.type))) and (flags==nil or el.param==flags)) and (((revdir==false and el.from>index and el.from<e.from) or (revdir==true and el.to<index and el.to>e.to)))
                   end
                   return nil if e.type==0
@@ -1688,7 +1688,7 @@ end
 def text_html
   r=""
   objs={}
-  for e in @elements
+  @elements.each do |e|
     objs[e.from]||=[]
     objs[e.from].push(e.html_open)
     t=e.to
@@ -1697,10 +1697,10 @@ def text_html
     objs[t].insert(0, e.html_close)
   end
   l=0
-  for k in objs.keys.sort
+  objs.keys.sort.each do |k|
     o=objs[k]
     r+=html_encode(text_range_exclusive(l,k))
-    for b in o
+    o.each do |b|
       r+=b
     end
     l=k
@@ -1720,7 +1720,7 @@ def value
     play_sound("editbox_audiomarker", volume: 100, pitch: 100, pan: pos) if spk && Configuration.controlspresentation!=2
     end
       if spk && @sounds!=nil
-        for snd in @sounds
+        @sounds.each do |snd|
           play_sound(snd, volume: 100, pitch: 100, pan: pos)
           end
         end
@@ -1986,7 +1986,7 @@ end
      @@customactions.push([name, b, cls]) if b!=nil
    end
    def self.unregister_class(cls)
-     for a in @@customactions.dup
+     @@customactions.dup.each do |a|
        @@customactions.delete(a) if a[2]==cls
        end
      end
@@ -2101,7 +2101,7 @@ def initialize(options, header: "", index: 0, flags: 0, quiet: true)
       self.index = index
 self.options=(options)
                                                 @selected = []
-                                                            for i in 0..@options.size - 1
+                                                            (0..@options.size - 1).each do |i|
               @grayed[i] = false if @grayed[i]!=true
               @selected[i] = false
               end
@@ -2125,7 +2125,7 @@ self.options=(options)
               clear_item_audio
               @hotkeys||={}
               @hotkeys.clear
-                                                                                                                                                                                                                                      for i in 0..opts.size - 1
+                                                                                                                                                                                                                                      (0..opts.size - 1).each do |i|
                                                                           gray=false
               if opts[i]!=nil
                 ind=nil
@@ -2170,10 +2170,10 @@ def prepend_options(opts, states=[], audio_urls=[])
   old_audio_entries=@item_audio_entries.dup
   @item_audio_entries={}
   self.options=opts
-  for i in 0...states.size
+  (0...states.size).each do |i|
     set_item_states(i, states[i]) if states[i]!=nil
   end
-  for i in 0...audio_urls.size
+  (0...audio_urls.size).each do |i|
     set_item_audio(i, audio_urls[i]) if audio_urls[i]!=nil && audio_urls[i].to_s!=""
   end
   @options+=old_options
@@ -2424,7 +2424,7 @@ def speak_item_option(id=self.index, base=nil, prefix="", include_selection=true
   end
   if include_hotkey
     ss=false
-    for k in @hotkeys.keys
+    @hotkeys.keys.each do |k|
       ss = k if @hotkeys[k] == id
     end
     text=speech_value_append(text, " ("+text_utf8([ss.to_i & 0xff].pack("C"))+")") if ss.is_a?(Integer)
@@ -2563,7 +2563,7 @@ end
     end
   if key_pressed?(0x21) == true and @lr==false  && !key_held?(0x5B) && !key_held?(0x5C)
     if self.index > 14
-            for i in 1..15
+            (1..15).each do |i|
               self.index-=1
               while hidden?(self.index) == true and self.index>15-i
     self.index -= 1
@@ -2579,7 +2579,7 @@ end
     end
         if key_pressed?(0x22) == true and @lr==false  && !key_held?(0x5B) && !key_held?(0x5C)
        if self.index < (options.size - 15)
-            for i in 1..15
+            (1..15).each do |i|
               self.index+=1
                   while hidden?(self.index) == true and self.index<@options.size-i
     self.index += 1
@@ -2754,7 +2754,7 @@ end
                 b += "\r\n\r\n(#{text_utf8(p_("EAPI_Common", "Checked"))})" if @selected[self.index] == true
                 b += "\r\n\r\n(#{text_utf8(p_("EAPI_Common", "Unchecked"))})" if @selected[self.index] == false && @multi==true
                 ss = false
-                for k in @hotkeys.keys
+                @hotkeys.keys.each do |k|
                   ss = k if @hotkeys[k] == self.index
                 end
                 o=speech_value_append(o, " ("+text_utf8([ss.to_i & 0xff].pack("C"))+")") if ss.is_a?(Integer)
@@ -2822,7 +2822,7 @@ def tag
   end
   def multiselections
   ar=[]
-  for i in 0...@options.size
+  (0...@options.size).each do |i|
     ar.push(i) if @selected[i]
     end
   return ar
@@ -3311,7 +3311,7 @@ end
         files = Clipboard.files
         return if files.size==0
                 waiting {
-        for file in files
+        files.each do |file|
           src=file
           dst=EltenPath.join(@path, File.basename(file))
           if File.directory?(file)
@@ -3400,7 +3400,7 @@ super
   @opfocused=false
         if @sel.selected? or @sel.expanded?
     o=@options.deep_dup
-    for l in @way
+    @way.each do |l|
       o=o[l][1..o[l].size-1]
     end
         if o[@sel.index].is_a?(Array)
@@ -3440,11 +3440,11 @@ super
          def searchway(way=[],tway=[],index=0)
                                  return [index,tway] if way==tway
            t=@options.deep_dup
-                      for l in tway
+                      tway.each do |l|
              t=(t[l]==nil)?nil:(t[l][1..t[l].size-1])
            end
            return [index,tway] if t.is_a?(Array)==false
-                                 for i in 0..t.size-1
+                                 (0..t.size-1).each do |i|
                           x=searchway(way,tway+[i],index+1)
                if x[1]==way
                                  return x
@@ -3460,11 +3460,11 @@ super
                                  end
          def getelements(way=[])
 sou=@options.deep_dup
-         for l in way
+         way.each do |l|
            sou=sou[l][1..sou[l].size-1]
                 end
               ret=sou
-for i in 0..ret.size-1
+(0..ret.size-1).each do |i|
   while ret[i].is_a?(Array)
     ret[i]=ret[i][0]
     end
@@ -3488,7 +3488,7 @@ return ret
       def selector(options, header: "", start_index: 0, cancel_index: nil, flags: 0, border: true, cancel_key: nil)
         dialog_open
         dis=[]
-        for i in 0..options.size-1
+        (0..options.size-1).each do |i|
           if options[i]==nil
             dis.push(i)
             options[i]=""
@@ -3497,7 +3497,7 @@ return ret
           list_flags=flags
           list_flags=ListBox::Flags::AnyDir if flags==1
 lsel=ListBox.new(options, header: header, index: start_index, flags: list_flags)
-      for d in dis
+      dis.each do |d|
         lsel.disable_item(d)
       end
       lsel.focus
@@ -3528,7 +3528,7 @@ lsel=ListBox.new(options, header: header, index: start_index, flags: list_flags)
         
         def menuselector(options)
         dis=[]
-        for i in 0..options.size-1
+        (0..options.size-1).each do |i|
           if options[i]==nil
             dis.push(i)
             options[i]=""
@@ -3538,7 +3538,7 @@ lsel=""
         play_sound("menu_open")
         Menu.menubg_play if Configuration.bgsounds==1 && Configuration.soundthemeactivation==1
 lsel = ListBox.new(options, header: "", index: 0, flags: ListBox::Flags::AnyDir)
-                    for d in dis
+                    dis.each do |d|
         lsel.disable_item(d)
       end
       lsel.update
@@ -3694,13 +3694,13 @@ lsel = ListBox.new(options, header: "", index: 0, flags: ListBox::Flags::AnyDir)
          end
          def apply_row_audio
            return if @row_audio_urls==nil
-           for i in 0...@row_audio_urls.size
+           (0...@row_audio_urls.size).each do |i|
              @sel.set_item_audio(i, @row_audio_urls[i]) if @row_audio_urls[i]!=nil && @row_audio_urls[i].to_s!=""
            end
          end
          def apply_row_states
            return if @row_states==nil
-           for i in 0...@row_states.size
+           (0...@row_states.size).each do |i|
              @sel.set_item_states(i, @row_states[i]) if @row_states[i]!=nil
            end
          end
@@ -3723,13 +3723,13 @@ lsel = ListBox.new(options, header: "", index: 0, flags: ListBox::Flags::AnyDir)
 alias sayoption say_option
            def format_rows(col=0)
            opts=[]
-           for r in @rows
+           @rows.each do |r|
              if r==nil or r.count(nil)==r.size
                o=nil
                               else
              o=""
                           o=row_speech_value(r[col]) if r[col]!=nil
-             for c in 0...@columns.size
+             (0...@columns.size).each do |c|
                if c!=col&&r[c]!=nil
                plain=o.to_s
                o=row_speech_append(o, ((c==0)?":":((plain[-1..-1]!=":"&&plain[-1..-1]!=".")?",":""))+" ")
@@ -3839,8 +3839,8 @@ super
              @x = [[@x.to_i, 0].max, @width - 1].min
              @y = [[@y.to_i, 0].max, @height - 1].min
              @labels = Array.new(@height) { Array.new(@width, "") }
-             for row in 0...[@height, old.size].min
-               for col in 0...[@width, old[row].to_a.size].min
+             (0...[@height, old.size].min).each do |row|
+               (0...[@width, old[row].to_a.size].min).each do |col|
                  @labels[row][col] = old[row][col]
                end
              end
@@ -4095,7 +4095,7 @@ def getposition(pos, len)
   (0..hours).each{|h|lst_hour.options.push(h.to_s)}
   lst_hour.on(:move) {
   t=(len-lst_hour.index*3600)/60
-  for i in 0..59
+  (0..59).each do |i|
     if t<=i
       lst_min.disable_item(i)
     else
@@ -4106,7 +4106,7 @@ def getposition(pos, len)
   }
   lst_min.on(:move) {
     t=(len-lst_hour.index*3600-lst_min.index*60)
-  for i in 0..59
+  (0..59).each do |i|
     if t<=i
       lst_sec.disable_item(i)
     else
@@ -4138,11 +4138,11 @@ def savefile
     nm=@label.delete("\r\n\\/:!@\#*?<>\'\"|+=`") if @label!="" and @label!=nil
         nm+=".opus"
         encoders=[]
-        for e in MediaEncoders.list
+        MediaEncoders.list.each do |e|
           encoders.push(e) if e::Type==:audio
           end
         formats=[]
-        for e in encoders
+        encoders.each do |e|
           f=e::Name+" ("+e::Extension+")"
           if e::Extension.downcase==".opus" && is_opus?
             f+= " ("+p_("EAPI_Form", "Copy original stream")+")"
@@ -4167,7 +4167,7 @@ def savefile
         }
         edt_filename.on(:change) {
         ext=File.extname(edt_filename.text)
-        for i in 0...encoders.size
+        (0...encoders.size).each do |i|
           if encoders[i]::Extension.downcase==ext.downcase
             lst_format.index=i
             break
@@ -4236,7 +4236,7 @@ def completed
 
 def fade
   return if get_sound==nil
-  for i in 1..20
+  (1..20).each do |i|
     loop_update
     get_sound.volume-=0.05
     if get_sound.volume<=0.05
@@ -4297,7 +4297,7 @@ h=d/3600
     [p_("EAPI_Form", "Track number"), ai.track_number],
     [p_("EAPI_Form", "Copyright"), ai.copyright]
         ]
-       for a in fields.deep_dup
+       fields.deep_dup.each do |a|
                   fields.delete(a) if a[1]==nil || a[1]==""
        end
        sel=TableBox.new(["",""], fields, index: 0, header: "", quiet: false)
@@ -4455,11 +4455,11 @@ class Menu
     s=0
     inds=[]
     depth=0
-    for i in 0...index
+    (0...index).each do |i|
       depth+=1 if @options[i].is_a?(String)
       depth-=1 if @options[i]==nil
       end
-    for i in index...@options.size
+    index...@options.size.each do |i|
       c=@options[i]
       if s==0
         break if c==nil
@@ -4707,9 +4707,9 @@ end
     def path(x,y,ox,oy,walls,width,height)
             return [[x,y]] if x==ox&&y==oy
             mat=[]
-            for i in 0...width
+            (0...width).each do |i|
               mat[i]=[]
-              for j in 0...height
+              (0...height).each do |j|
                 s=true
                 s=false if walls.include?([i,j])
                 mat[i][j]=s
@@ -4873,7 +4873,7 @@ def wall(x1, y1, x2=nil, y2=nil)
       play_sound(@direction_sound) if @direction_sound!=nil
       return if @direction_delay
       end
-      for w in @walls
+      @walls.each do |w|
         if w[0]==x&&w[1]==y
           play_sound(@wall_sound) if @wall_sound!=nil
           trigger(:wall)
@@ -4882,7 +4882,7 @@ def wall(x1, y1, x2=nil, y2=nil)
       end
       play_sound(@move_sound) if @move_sound!=nil
       @x,@y=x,y
-      for ac in @actions
+      @actions.each do |ac|
         ac[2].call if ac[0]==x and ac[1]==y
       end
             trigger(:move)
@@ -5107,7 +5107,7 @@ def show_encodersettings
 [p_("EAPI_Form", "High"), 96, 20, 1],
 [p_("EAPI_Form", "Max"), @max_bitrate, ((@max_bitrate>80)?20:40), 1]
   ]
-  for pr in profiles
+  profiles.each do |pr|
     profiles.delete(pr) if pr[1]>@max_bitrate
     end
   appind=@application==2048?0:1
@@ -5139,7 +5139,7 @@ else
   end
   }
   suc=false
-  for i in 0...profiles.size
+  (0...profiles.size).each do |i|
     pr=profiles[i]
     bitrate = bitrates_available[lst_bitrate.index]
     framesize = framesizes_available[lst_framesize.index]
@@ -5171,7 +5171,7 @@ end
 def bitrates_available
   all = [8, 16, 24, 32, 48, 64, 80, 96, 128, 160, 196, 256, 320]
   m=[]
-  for b in all
+  all.each do |b|
     m.push(b) if b<=@max_bitrate
   end
   return m
@@ -5207,13 +5207,13 @@ def edit_tags
 'COPYRIGHT'=>p_("EAPI_Form", "Copyright"),
 }
 opts=[]
-for k in editable_tags
+editable_tags.each do |k|
 v = mapper[k]||k
 opts.push("#{v}: #{tgs[k]||""}")
   end
 lst_tags.options=opts
 opts=[]
-for i in 0..999
+(0..999).each do |i|
   next if tgs["CHAPTER#{sprintf("%03d", i)}"]==nil
 time = tgs["CHAPTER#{sprintf("%03d", i)}"]
   name = tgs["CHAPTER#{sprintf("%03d", i)}NAME"]||""
@@ -5223,7 +5223,7 @@ lst_chapters.options = opts
   }
   getchaps = Proc.new {
   chaps=[]
-  for i in 0..999
+  (0..999).each do |i|
   next if tgs["CHAPTER#{sprintf("%03d", i)}"]==nil
 time = tgs["CHAPTER#{sprintf("%03d", i)}"]
   name = tgs["CHAPTER#{sprintf("%03d", i)}NAME"]||""
@@ -5235,7 +5235,7 @@ chaps
   }
   setchaps = Proc.new{|chaps|
 chaps=chaps.sort_by{|c|c[0]}
-  for i in 0...chaps.size
+  (0...chaps.size).each do |i|
 tgs["CHAPTER#{sprintf("%03d", i)}"]=chaps[i][0]
 tgs["CHAPTER#{sprintf("%03d", i)}NAME"] = chaps[i][1]||""
 end

--- a/src/eapi/dictionary.rb
+++ b/src/eapi/dictionary.rb
@@ -63,7 +63,7 @@ module EltenAPI
      def getlocale(code)
        normalized=normalize_locale_code(code)
        lang=nil
-     for l in Languages
+     Languages.each do |l|
       if l.realcode.downcase==normalized.downcase
         lang=l
         break
@@ -74,7 +74,7 @@ module EltenAPI
        def setlocale(code)
     code=normalize_locale_code(code)
     lang=nil
-    for l in Languages
+    Languages.each do |l|
       if l.realcode.downcase==code.downcase
         lang=l
         break
@@ -87,7 +87,7 @@ module EltenAPI
    if defined?(Programs) && Programs.respond_to?(:language_locale_data)
      Programs.language_locale_data(code).each { |data| loadmo(data, false) }
    end
- for d in lang.docs
+ lang.docs.each do |d|
    Docs[d[0]]=d[1]
    end
 end
@@ -118,7 +118,7 @@ end
   Params[1]+=n
   src=data[12..15].unpack("I").first
   dst=data[16..19].unpack("I").first
-  for i in 0...n
+  (0...n).each do |i|
 src_length = data[src+8*i..src+8*i+3].unpack("I").first
 src_offset = data[src+8*i+4..src+8*i+7].unpack("I").first
 dst_length = data[dst+8*i..dst+8*i+3].unpack("I").first
@@ -156,7 +156,7 @@ def n_(*pr)
  end
  forms=[]
  n=0
- for param in pr
+ pr.each do |param|
    if param.is_a?(String)
    forms.push(param)
  elsif param.is_a?(Integer)
@@ -266,14 +266,14 @@ end
 def find(*forms)
   c=DictCache[forms.first]
   return forms if c==nil
-  for i in c
+  c.each do |i|
     return Translations[i].map{|s|s.force_encoding(Encoding::UTF_8)} if Sources[i].size>=forms.size && Sources[i][0...forms.size]==forms
   end
   return forms.map{|s|s.force_encoding(Encoding::UTF_8)}
 end
 def setparams(t)
   pr=t.split("\n")
-  for param in pr
+  pr.each do |param|
     c=param.index(": ")
     next if c==nil
     head=param[0...c]

--- a/src/eapi/documents.rb
+++ b/src/eapi/documents.rb
@@ -532,7 +532,7 @@ the work, and under which the third party grants, to any of the
 parties who would receive the covered work from you, a discriminatory
 patent license (a) in connection with copies of the covered work
 conveyed by you (or copies made from those copies), or (b) primarily
-for and in connection with specific products or compilations that
+connection with specific products or compilations that.each do |and|
 contain the covered work, unless you entered into that arrangement,
 or that patent license was granted, prior to 28 March 2007.
 

--- a/src/eapi/eltensrv.rb
+++ b/src/eapi/eltensrv.rb
@@ -246,7 +246,7 @@ module EltenAPI
         speech_wait
       end
       selt = []
-      for i in 0..contact.size - 1
+      (0..contact.size - 1).each do |i|
         selt[i] = user_with_status(contact[i])
       end
       sel = ListBox.new(selt,header: p_("EAPI_Common", "Select contact"), index: 0, flags: 0, quiet: false)
@@ -366,7 +366,7 @@ module EltenAPI
       end
       if vc[1]!="     " and vc.size!=1
         text += "\r\n\r\n"
-        for i in 1..vc.size - 1
+        (1..vc.size - 1).each do |i|
           text += vc[i]
         end
       end

--- a/src/eapi/external.rb
+++ b/src/eapi/external.rb
@@ -32,7 +32,7 @@ text=text[0..5000]
   h=JSON.load(j)
   return "" if !h[0].is_a?(Array)
   t=""
-  for a in h[0]
+  h[0].each do |a|
     return "" if !a[0].is_a?(String)
     t+=a[0]
   end
@@ -48,14 +48,14 @@ text=text[0..5000]
 # @param text [String] a text to translate
      def translator(text)
   langs={}
-  for lk in Lists.langs.keys
+  Lists.langs.keys.each do |lk|
     lname=Lists.langs[lk]['nativeName']+" ("+Lists.langs[lk]['name']+")"
     langs[lk]=lname
     end
        dialog_open
   from=ListBox.new([p_("EAPI_External", "recognize automatically")]+langs.values,header: p_("EAPI_External", "source language"))
  ind=0
- for i in 0..langs.keys.size-1
+ (0..langs.keys.size-1).each do |i|
    ind=i if Configuration.language[0..1].downcase==langs.keys[i].downcase
    end
  to=ListBox.new(langs.values,header: p_("EAPI_External", "destination language"),index: ind)

--- a/src/eapi/keyboard.rb
+++ b/src/eapi/keyboard.rb
@@ -55,7 +55,7 @@ module EltenAPI
         first_pressed = Array.new(256, false)
         repeated = Array.new(256, false)
 
-        for key in 0..255
+        (0..255).each do |key|
           was_down = @held[key] == true
           is_down = down[key] == true
           held[key] = is_down
@@ -84,7 +84,7 @@ module EltenAPI
         end
 
         action_pressed = Array.new(256, false)
-        for key in 0..255
+        (0..255).each do |key|
           action_pressed[key] = pressed[key] == true || repeated[key] == true
           if action_pressed[key] == true
             if @last_pressed_tick[key].to_i == current_tick - 1
@@ -207,7 +207,7 @@ module EltenAPI
       def normalize_state(raw_state)
         bytes = raw_state.to_s.byteslice(0, 256).to_s.ljust(256, "\0")
         state = Array.new(256, false)
-        for key in 0..255
+        (0..255).each do |key|
           state[key] = (bytes.getbyte(key).to_i & 0x80) != 0
         end
         state
@@ -215,7 +215,7 @@ module EltenAPI
 
       def state_string(held)
         bytes = "\0" * 256
-        for key in 0..255
+        (0..255).each do |key|
           bytes.setbyte(key, held[key] ? 0x80 : 0)
         end
         bytes

--- a/src/eapi/log.rb
+++ b/src/eapi/log.rb
@@ -87,7 +87,7 @@ end
         lg=[]
         lgh=[]
 last=nil
-        for i in 0...Events.size
+        (0...Events.size).each do |i|
   l=Events[i]
   txt=l.to_s(dsplevel, dspdate)
   if l.level==nil

--- a/src/eapi/mainmenu.rb
+++ b/src/eapi/mainmenu.rb
@@ -28,7 +28,7 @@ module GlobalMenu
     style=:menubar if defaults
     @menu = Menu.new("",style)
     if $activecontrols!=nil
-        for c in $activecontrols||[]
+        $activecontrols||[].each do |c|
       if !c.menu_enabled?
         return
         end
@@ -82,7 +82,7 @@ module GlobalMenu
     end
     @menu.submenu(p_("MainMenu", "&Programs")) {|m|
     list=Programs.list
-    for prg in list
+    list.each do |prg|
       m.scene(prg.menu_label||prg.name||prg.to_s, prg) if !prg.hidden?
       end
     m.scene(p_("MainMenu", "Programs management"), Scene_Programs)
@@ -172,7 +172,7 @@ module GlobalMenu
     }
     if ($subthreads||[]).size>0 || $mainthread!=$currentthread
       @menu.submenu(p_("MainMenu", "&Windows")) {|m|
-      for i in -1...$subthreads.size
+      -1...$subthreads.size.each do |i|
         if i>=0
         sc=$subthreads[i]
       else

--- a/src/eapi/network.rb
+++ b/src/eapi/network.rb
@@ -19,7 +19,7 @@ while boundary=="" || values.any? { |value| value.include?(boundary) }
   boundary="----EltBoundary"+rand(36**32).to_s(36)
 end
 txt="".b
-for h in body.keys
+body.keys.each do |h|
 txt << ("--"+boundary+"\r\nContent-Disposition: form-data; name=\"#{h}\"\r\n\r\n").b
 txt << body[h].to_s.b
 txt << "\r\n".b
@@ -58,7 +58,7 @@ return nil
       waiting_end if w
 if headers!=nil
 headers.clear
-for k,v in response_headers
+response_headers.each do |k,v|
 headers[k]=v
 end
 end

--- a/src/eapi/quickactions.rb
+++ b/src/eapi/quickactions.rb
@@ -63,7 +63,7 @@ module EltenAPI
               if tps.size==0
                 text=p_("EAPI_Common", "No tips available")
               else
-                for i in 1...tps.size
+                (1...tps.size).each do |i|
                   next if tps[i].size<2
                   t=tps[i]+""
                   t[0..0]=t[0..0].downcase if t[1..1].downcase==t[1..1].downcase
@@ -202,7 +202,7 @@ end
     def load_json_actions(path)
       data=JSON.parse(File.binread(path).to_s)
       fail TypeError, "Quick actions JSON must be an array" if !data.is_a?(Array)
-      for ac in Array(data)
+      Array(data).each do |ac|
         action=normalize_record(ac)
         register(*action) if action!=nil
       end
@@ -215,7 +215,7 @@ end
     def migrate_legacy_actions
       begin
         d=load_data(legacy_data_path)
-        for ac in Array(d)
+        Array(d).each do |ac|
           action=normalize_record(ac)
           register(*action) if action!=nil
         end
@@ -293,7 +293,7 @@ end
 [:conference_dicerollcustom, p_("EAPI_QuickActions", "Conferences: roll a custom dice"), [], 0, false],
 [:alarm, p_("EAPI_QuickActions", "Add alarm"), [], 0, false],
         ]
-        for ac in @@addprocs
+        @@addprocs.each do |ac|
           a.push([ac[1], ac[2]])
           end
         end
@@ -389,7 +389,7 @@ end
     def generate_struct
       load_actions if @@actions==nil
             a=[]
-      for ac in @@actions
+      @@actions.each do |ac|
         b=quick_action_struct(ac)
         a.push(b) if b!=nil
       end
@@ -460,7 +460,7 @@ end
       index
     end
         def get_proc(pr)
-      for a in @@addprocs
+      @@addprocs.each do |a|
         return a[3] if a[1]==pr
       end
       return nil

--- a/src/eapi/recorder.rb
+++ b/src/eapi/recorder.rb
@@ -59,7 +59,7 @@ module EltenRecorderStructs
     def bass_channel_info_values(buffer)
       filename_offset = POINTER_SIZE == 8 ? 32 : 28
       values = []
-      for i in 0...7
+      (0...7).each do |i|
         values.push(dword_value(buffer, i * 4))
       end
       values.push(pointer_value(buffer, filename_offset))
@@ -214,7 +214,7 @@ module EltenRecorderRuntime
       tags = {}
       ai = AudioInfo.new(channel)
       chapters = ai.chapters
-      for i in 0...chapters.size
+      (0...chapters.size).each do |i|
         chapter = chapters[i]
         key = sprintf("CHAPTER%03d", i)
         time = chapter.time.to_f
@@ -888,11 +888,11 @@ class VorbisAudioEncoder < AudioEncoder
     buffer = VorbisNative.analysis_buffer.call(@vd, frames)
     pointer_table = Fiddle::Pointer.new(buffer.to_i)[0, @channels * EltenRecorderStructs::POINTER_SIZE]
     samples = pcm.unpack("s<*")
-    for channel in 0...@channels
+    (0...@channels).each do |channel|
       pointer = Fiddle::Pointer.new(EltenRecorderStructs.pointer_value(pointer_table, channel * EltenRecorderStructs::POINTER_SIZE))
       values = Array.new(frames)
       index = channel
-      for frame in 0...frames
+      (0...frames).each do |frame|
         values[frame] = samples[index].to_f / 32768.0
         index += @channels
       end

--- a/src/eapi/sound.rb
+++ b/src/eapi/sound.rb
@@ -192,7 +192,7 @@ class AudioInfo
           when :UTF16
             content = deunicode(content)
           when :UnicodeFFE
-            for i in 0...content.bytesize / 2
+            (0...content.bytesize / 2).each do |i|
               s = i * 2
               c = content[s]
               content[s] = content[s + 1]
@@ -220,13 +220,13 @@ class AudioInfo
     if t != nil
       tgs = {}
       mapper = {"TIT2" => "TITLE", "TALB" => "ALBUM", "TPE1" => "ARTIST", "TRCK" => "TRACKNUMBER", "TCOM" => "COMPOSER", "TCOP" => "COPYRIGHT"}
-      for d, o in mapper
+      mapper.each do |d, o|
         f = t.find { |frame| frame.id == d }
         tgs[o] = f.strvalue if f != nil
       end
       chs = t.select { |frame| frame.id == "CHAP" }
       i = 0
-      for c in chs
+      chs.each do |c|
         time = c.numvalue / 1000.0
         name = ""
         sf = c.subframes.find { |s| s.id == "TIT2" }
@@ -266,7 +266,7 @@ class AudioInfo
     return @chapters if @chapters != nil && @chapters != []
     chapters = []
     if (t = tags_ogg) != nil
-      for i in 0..999
+      (0..999).each do |i|
         d = sprintf("%03d", i)
         if t["CHAPTER#{d}"] != nil && t["CHAPTER#{d}NAME"] != nil
           tm = t["CHAPTER#{d}"]
@@ -281,12 +281,12 @@ class AudioInfo
       end
     end
     if (t = tags_id3v2) != nil
-      for f in t
+      t.each do |f|
         if f.id == "CHAP" && f.subframes.size > 0
           c = Chapter.new
           c.time = f.numvalue / 1000.0
           c.name = ""
-          for g in f.subframes
+          f.subframes.each do |g|
             c.name = g.strvalue if g.id == "TIT2"
           end
           chapters.push(c)
@@ -304,7 +304,7 @@ class AudioInfo
       return t[ogg.upcase] if t[ogg.upcase] != nil
     end
     if (t = tags_id3v2) != nil
-      for r in t
+      t.each do |r|
         return r.strvalue[0...r.strvalue.index("\0") || r.strvalue.size] if r.id == id3
       end
     end

--- a/src/eapi/speech.rb
+++ b/src/eapi/speech.rb
@@ -22,6 +22,16 @@ module EltenAPI
       nvda != nil && nvda.respond_to?(:check) && nvda.check
     end
 
+    def braille_output
+      nvda = nvda_output
+      return nvda if nvda != nil && nvda.respond_to?(:check) && nvda.check && nvda.respond_to?(:braille_alert)
+      SpeechOutput.list.find { |o| o != nvda && o.braille_supported? && o.respond_to?(:usable?) && o.usable? }
+    end
+
+    def braille_check?
+      braille_output != nil
+    end
+
     def speech_output
       output = SpeechOutput.current_output
       nvda = nvda_output
@@ -64,10 +74,11 @@ module EltenAPI
     def alert(text, wait=true)
       Programs.emit_event(:speech_alert)
       speak(text)
-      braille=text.is_a?(SpeechSequence) ? text.braille_text : text
-      nvda_output.braille_alert(braille) if nvda_check?
+      braille = text.is_a?(SpeechSequence) ? text.braille_text : text
+      out = braille_output
+      out.braille_alert(braille) if out != nil
       speech_wait if wait
-      end
+    end
   
       @@current_speechsequence=nil
       def current_speechsequence

--- a/src/eapi/speexdsp.rb
+++ b/src/eapi/speexdsp.rb
@@ -90,7 +90,7 @@ return b
 end
 def set_echo(ec)
 return nil if !ec.is_a?(Echo)
-for i in 0...@preprocessors.size
+(0...@preprocessors.size).each do |i|
 pc=EltenNativeStructs.pointer_buffer(ec.echoes[i])
 Preprocess_ctl.call(@preprocessors[i], SPEEX_PREPROCESS_SET_ECHO_STATE, pc)
 end
@@ -109,7 +109,7 @@ while (audio.bytesize-index)>=@stepsize
 frg=audio.byteslice(index...index+@stepsize)
 channels=[]
 sources=frg.unpack("s*").each_slice(@ch).to_a.transpose
-for c in 0...@ch
+(0...@ch).each do |c|
 frame=sources[c].pack("s*")
 Preprocess_run.call(@preprocessors[c], frame)
 channels[c]=frame.unpack("s*")
@@ -126,7 +126,7 @@ return ""
 end
 private
 def setctl_int(flag, value)
-for pr in @preprocessors
+@preprocessors.each do |pr|
 pc=[value].pack("i")
 Preprocess_ctl.call(pr, flag, pc)
 end
@@ -137,7 +137,7 @@ Preprocess_ctl.call(@preprocessors[0], flag, pc)
 return pc.unpack("i").first
 end
 def setctl_float(flag, value)
-for pr in @preprocessors
+@preprocessors.each do |pr|
 pc=[value].pack("f")
 Preprocess_ctl.call(pr, flag, pc)
 end
@@ -173,10 +173,10 @@ return indata if indata.bytesize>outdata.bytesize
 return indata if indata.bytesize!=@stepsize
 indata=indata.byteslice(0...outdata.bytesize) if indata.bytesize>outdata.bytesize
 out="\0"*indata.bytesize
-for c in 0...@ch
+(0...@ch).each do |c|
 inframe=("\0"*(@stepsize/@ch)).b
 outframe=("\0"*(@stepsize/@ch)).b
-for i in 0...(@stepsize/@ch/2)
+(0...(@stepsize/@ch/2)).each do |i|
 inframe.setbyte(i*2, indata.getbyte(2*(@ch*i+c)))
 outframe.setbyte(i*2, outdata.getbyte(2*(@ch*i+c)))
 inframe.setbyte(i*2+1, indata.getbyte(2*(@ch*i+c)+1))
@@ -184,7 +184,7 @@ outframe.setbyte(i*2+1, outdata.getbyte(2*(@ch*i+c)+1))
 end
 resframe="\0"*inframe.bytesize
 Echo_cancellation.call(@echoes[c], inframe, outframe, resframe)
-for i in 0...@stepsize/@ch/2
+(0...@stepsize/@ch/2).each do |i|
 out.setbyte(2*(@ch*i+c), resframe.getbyte(i*2))
 out.setbyte(2*(@ch*i+c)+1, resframe.getbyte(i*2+1))
 end
@@ -198,15 +198,15 @@ ret=""
 while (audio.bytesize-index)>=@stepsize
 frg=audio.byteslice(index...index+@stepsize)
 out=("\0"*@stepsize).b
-for c in 0...@ch
+(0...@ch).each do |c|
 frame=("\0"*(@stepsize/@ch)).b
 resframe="\0"*frame.bytesize
-for i in 0...(@stepsize/@ch/2)
+(0...(@stepsize/@ch/2)).each do |i|
 frame.setbyte(i*2, frg.getbyte(2*(@ch*i+c)))
 frame.setbyte(i*2+1, frg.getbyte(2*(@ch*i+c)+1))
 end
 Echo_capture.call(@echoes[c], frame, resframe)
-for i in 0...@stepsize/@ch/2
+(0...@stepsize/@ch/2).each do |i|
 out.setbyte(2*(@ch*i+c), resframe.getbyte(i*2))
 out.setbyte(2*(@ch*i+c)+1, resframe.getbyte(i*2+1))
 end
@@ -224,15 +224,15 @@ ret=""
 while (audio.bytesize-index)>=@stepsize
 frg=audio.byteslice(index...index+@stepsize)
 out=("\0"*@stepsize).b
-for c in 0...@ch
+(0...@ch).each do |c|
 frame=("\0"*(@stepsize/@ch)).b
 resframe="\0"*frame.bytesize
-for i in 0...(@stepsize/@ch/2)
+(0...(@stepsize/@ch/2)).each do |i|
 frame.setbyte(i*2, frg.getbyte(2*(@ch*i+c)))
 frame.setbyte(i*2+1, frg.getbyte(2*(@ch*i+c)+1))
 end
 Echo_playback.call(@echoes[c], frame, resframe)
-for i in 0...@stepsize/@ch/2
+(0...@stepsize/@ch/2).each do |i|
 out.setbyte(2*(@ch*i+c), resframe.getbyte(i*2))
 out.setbyte(2*(@ch*i+c)+1, resframe.getbyte(i*2+1))
 end
@@ -245,7 +245,7 @@ return ret
 end
 private
 def setctl_int(flag, value)
-for pr in @echoes
+@echoes.each do |pr|
 pc=[value].pack("i")
 Echo_ctl.call(pr, flag, pc)
 end
@@ -256,7 +256,7 @@ Echo_ctl.call(@echoes[0], flag, pc)
 return pc.unpack("i").first
 end
 def setctl_float(flag, value)
-for pr in @echoes
+@echoes.each do |pr|
 pc=[value].pack("f")
 Echo_ctl.call(pr, flag, pc)
 end

--- a/src/eapi/structs.rb
+++ b/src/eapi/structs.rb
@@ -1,4 +1,4 @@
-﻿# A part of Elten - EltenLink / Elten Network desktop client.
+# A part of Elten - EltenLink / Elten Network desktop client.
 # Copyright (C) 2014-2021 Dawid Pieper
 # Elten is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 3. 
 # Elten is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details. 
@@ -52,7 +52,7 @@ module EltenAPI
         attr_accessor :listtype, :usepan, :soundcard, :microphone, :controlspresentation, :contextmenubar, :soundthemeactivation, :typingecho, :linewrapping, :hidewindow, :synctime, :registeractivity, :voice, :language, :voicerate, :voicevolume, :soundtheme, :volume, :usefx, :bgsounds, :voicepitch, :usedenoising, :autologin, :roundupforms, :checkupdates, :enablebraille, :useechocancellation, :usevoicedictionary, :disablefeednotifications, :iimodifiers, :iicards, :usebilinearhrtf, :sessiontime, :disablehttp2, :tcpconferences, :udppacketsize, :conferencesaudiobuffer , :conferencesaudiobuffercutoff, :disableconferencemiconrecord, :enableaudiobuffering, :saytimeperiod, :saytimetype, :autoplay, :branch
         def to_h
           h={}
-          for v in instance_variables
+          instance_variables.each do |v|
             h[v[1..-1]]=instance_variable_get(v)
             end
           return h

--- a/src/eapi/ui.rb
+++ b/src/eapi/ui.rb
@@ -1,4 +1,4 @@
-﻿# A part of Elten - EltenLink / Elten Network desktop client.
+# A part of Elten - EltenLink / Elten Network desktop client.
 # Copyright (C) 2014-2026 Dawid Pieper
 # Elten is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 3. 
 # Elten is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details. 
@@ -410,7 +410,7 @@ Bass::BASS_ChannelSetAttribute.call(stream, 2, volume.to_f/100.0)
 tokeys=[]
 if defined?(NVDA) && NVDA.check
   g=NVDA.getgestures
-  for k in g
+  g.each do |k|
         k=k.downcase
         if k=='kb(laptop):nvda+a' or k=='kb(desktop):nvda+downarrow'
           tokeys.push(0x2D,0x28)
@@ -430,7 +430,7 @@ if $setkeys.is_a?(Array)
         def keyboard_events_from_flags(flags)
           flags = flags.to_s.byteslice(0, 256).to_s.ljust(256, "\0")
           events = []
-          for key in 0...256
+          (0...256).each do |key|
             flag = flags.getbyte(key).to_i
             if (flag & 1) != 0
               events << [key, ((flag & 4) != 0 ? :repeat : true)]
@@ -564,13 +564,13 @@ if $setkeys.is_a?(Array)
     end
   end
   ac=QuickActions.get
-  for i in 1..11
+  (1..11).each do |i|
     k=0x6F+i
     if key_first_pressed?(k) && !key_held?(0x12)
       l=i
       l+=12 if key_held?(0x11)
       l*=-1 if key_held?(0x10)
-            for a in ac
+            ac.each do |a|
         a.call if a.key==l
         end
       end
@@ -579,7 +579,7 @@ if $setkeys.is_a?(Array)
   if !key_held?(0x12) && key_any_pressed?
     if key_any_pressed?
     t=GlobalMenu.ctitems
-for m in t
+t.each do |m|
   l=m[3]
   k, shift = keycode(l)
   if key_first_pressed?(k) && key_held?(0x10)==shift && ((key_held?(0x11) && !l.is_a?(Symbol)) || (l.is_a?(Symbol) && !key_held?(0x11))) && m[1].is_a?(Proc)
@@ -803,7 +803,7 @@ end
              update_premiumpackages(d['premiumpackages'].to_s.split(","))
            elsif d['func']=="feeds"
              changed_feeds = d['changed'].is_a?(String) ? JSON.parse(d['changed']) : Array(d['changed'])
-             for f in changed_feeds
+             changed_feeds.each do |f|
                feed = FeedMessage.new(f['id'], f['user'], f['time'], f['message'], f['response'], f['responses'], f['liked'], f['likes'])
                Session.feeds[feed.id]=feed
              end
@@ -985,7 +985,7 @@ if $agalarm==true and $alarmproc!=true
   if checkControls
   $activecontrols||=[]
   $lastactivecontrols||=[]
-  for c in $lastactivecontrols
+  $lastactivecontrols.each do |c|
     c.blur if !$activecontrols.include?(c)
   end
   $lastactivecontrols=$activecontrols.dup

--- a/src/eltenlink/client.rb
+++ b/src/eltenlink/client.rb
@@ -115,6 +115,7 @@ module EltenLink
         @context == nil ? sleep(0.01) : call_context(:loop_update, false)
         if Time.now.to_f - started > timeout.to_f
           @last_error = Error.timeout(module_name: safe_request_path)
+          call_context(:waiting_end)
           break
         end
       end

--- a/src/eltenlink/polls.rb
+++ b/src/eltenlink/polls.rb
@@ -172,7 +172,7 @@ module EltenLink
       def parse_short_list(lines)
         polls = []
         return polls if lines[1].to_i <= 0
-        for index in 1...lines.size
+        (1...lines.size).each do |index|
           clean = EltenLink.clean_line(lines[index])
           next unless index == 1 || EltenLink.legacy_end?(clean)
           id = lines[index + 1].to_i

--- a/src/eltenlink/voip.rb
+++ b/src/eltenlink/voip.rb
@@ -187,7 +187,7 @@ if resp['params']!=nil
 end
 end
 if resp.is_a?(Hash) && resp['packets'].is_a?(Array)
-for data in resp['packets'].map{|pc|Base64.decode64(pc)}
+resp['packets'].map{|pc|Base64.decode64(pc)}.each do |data|
 receive(data)
 end
 end
@@ -255,7 +255,7 @@ mutes.each{|m|mute(m)}
 chat_mutes.each{|m|chat_mute(m)}
 streams_mutes.each{|m|streams_mute(m)}
 streamid_mutes.each{|m|streamid_mute(m)}
-for i in 0...@streams.size
+(0...@streams.size).each do |i|
 s=@streams[i]
 if s!=nil
 @streams[i][:id]=command("stream_add", {'name'=>s[:name], 'channels'=>s[:channels], 'x'=>s[:x], 'y'=>s[:y]})['id']||0
@@ -338,7 +338,7 @@ end
 def send_multi(packets)
 return if !packets.is_a?(Array)
 coll=[]
-for pc in packets
+packets.each do |pc|
 if pc.size>2
 m=generate_packet(pc[0], pc[1], pc[2]||0, pc[3]||0, pc[4]||0, pc[5]||0, pc[6]||nil, pc[7]||nil, pc[8]||false)
 if m!=nil
@@ -627,7 +627,7 @@ if @receivetimes.size>50
 s=0
 r=0
 c=0
-for ind in @receivetimes.keys
+@receivetimes.keys.each do |ind|
 if @sendtimes[ind]!=nil
 r+=@receivetimes[ind]
 s+=@sendtimes[ind]
@@ -676,10 +676,10 @@ if CommandAliases[cmd].is_a?(Numeric)
 json[':c']=CommandAliases[cmd]
 json.delete(":command")
 end
-for k in params.keys
+params.keys.each do |k|
 json[k]=params[k]
 end
-for k in json.keys
+json.keys.each do |k|
 if json[k].is_a?(String)
 json[k]=json[k]+""
 json[k].force_encoding("UTF-8")

--- a/src/main.rb
+++ b/src/main.rb
@@ -1,35 +1,35 @@
 # A part of Elten - EltenLink / Elten Network desktop client.
 # Copyright (C) 2014-2026 Dawid Pieper
-# Elten is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 3. 
-# Elten is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details. 
-# You should have received a copy of the GNU General Public License along with Elten. If not, see <https://www.gnu.org/licenses/>. 
+# Elten is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 3.
+# Elten is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License along with Elten. If not, see <https://www.gnu.org/licenses/>.
 
 class Object
   include EltenAPI
-  end
+end
 
 module Elten
-VERSION_STRING="ELTEN 3.0 BETA 16"
-BRANCH="beta"
-class <<self
-  def version
-  return VERSION_STRING
-end
-def build_id
-  return nil if !const_defined?(:BuildID,false)
-  return const_get(:BuildID)
-end
-def build_date
-  return nil if !const_defined?(:BuildDate,false) || const_get(:BuildDate)==nil
-  t=Time.at(const_get(:BuildDate))
-  return sprintf("%04d-%02d-%02d %02d:%02d",t.year,t.month,t.day,t.hour,t.min)
-rescue Exception
-  nil
-end
-def branch
-  return BRANCH
+  VERSION_STRING="ELTEN 3.0 BETA 16"
+  BRANCH="beta"
+  class <<self
+    def version
+      return VERSION_STRING
+    end
+    def build_id
+      return nil if !const_defined?(:BuildID,false)
+      return const_get(:BuildID)
+    end
+    def build_date
+      return nil if !const_defined?(:BuildDate,false) || const_get(:BuildDate)==nil
+      t=Time.at(const_get(:BuildDate))
+      return sprintf("%04d-%02d-%02d %02d:%02d",t.year,t.month,t.day,t.hour,t.min)
+    rescue Exception
+      nil
+    end
+    def branch
+      return BRANCH
+    end
   end
-end
 end
 
 def mac_quit_shortcut_request
@@ -39,91 +39,91 @@ rescue Exception
 end
 
 begin
-Dirs.eltendata = EltenBoot.early_datadir if defined?(EltenBoot)
-FileUtils.mkdir_p(Dirs.eltendata)
+  Dirs.eltendata = EltenBoot.early_datadir if defined?(EltenBoot)
+  FileUtils.mkdir_p(Dirs.eltendata)
 end
 
 begin
-Log.head("Starting Elten")
-Log.head("Elten version: #{Elten.version.to_s}")
-Log.head("Ruby version: #{RUBY_DESCRIPTION.to_s}")
-    loop_update_window
-        Configuration.volume=50 if Configuration.volume==nil
-      $mainthread = Thread::current
-      $currentthread=$mainthread
+  Log.head("Starting Elten")
+  Log.head("Elten version: #{Elten.version.to_s}")
+  Log.head("Ruby version: #{RUBY_DESCRIPTION.to_s}")
+  loop_update_window
+  Configuration.volume=50 if Configuration.volume==nil
+  $mainthread = Thread::current
+  $currentthread=$mainthread
   $LOAD_PATH << "."
 end
-  begin
+begin
   #main
   # Make scene object (title screen)
-    if $toscene != true
+  if $toscene != true
     $scene = Scene_Loading.new if $tomain == nil and $updating != true and $downloading != true
-  $scene = Scene_Main.new if $tomain == true
-  $scene = Scene_Update.new if $updating == true
-  $scene = $scene if $downloading == true
-end
-$toscene = false
+    $scene = Scene_Main.new if $tomain == true
+    $scene = Scene_Update.new if $updating == true
+    $scene = $scene if $downloading == true
+  end
+  $toscene = false
   # Call main method as long as $scene is effective
   loop do
-  $scene=Scene_Loading.new if $restart==true
-          if $scene != nil and $exit!=true
-        $notifications_callback = nil
-        Log.debug("Loading scene: #{$scene.class.to_s}")
-                              $scene.main
-  else
-    break
+    $scene=Scene_Loading.new if $restart==true
+    if $scene != nil and $exit!=true
+      $notifications_callback = nil
+      Log.debug("Loading scene: #{$scene.class.to_s}")
+      $scene.main
+    else
+      break
     end
   end
   if $immediateexit!=true
-      register_activity(wait: true, final: true)
-      if defined?(Session) && Session.logged? && Session.name.to_s != "guest"
-        begin
-          EltenLink::System.logout_session(EltenLink.client(nil))
-          Log.info("Session token invalidated on shutdown")
-        rescue Exception
-          Log.warning("Session token invalidation failed on shutdown: #{$!.class}: #{$!.message}") if defined?(Log)
-        end
+    register_activity(wait: true, final: true)
+    if defined?(Session) && Session.logged? && Session.name.to_s != "guest"
+      begin
+        EltenLink::System.logout_session(EltenLink.client(nil))
+        Log.info("Session token invalidated on shutdown")
+      rescue Exception
+        Log.warning("Session token invalidation failed on shutdown: #{$!.class}: #{$!.message}") if defined?(Log)
       end
-      play_sound("logout")
+    end
+    play_sound("logout")
     delay(1)
-          speech_wait
-              $exit = true
-  if $exitupdate==true
-    installer=platform_installer_path
-    if $exitupdate_donotsilent!=true
-    File.binwrite(EltenPath.join(Dirs.eltendata, "update.last"),Zlib::Deflate.deflate(Elten.version.to_s))
-    $exit_runproc=platform_update_install_command(installer, silent: true)
-  else
-    $exit_runproc=platform_update_install_command(installer, silent: false)
+    speech_wait
+    $exit = true
+    if $exitupdate==true
+      installer=platform_installer_path
+      if $exitupdate_donotsilent!=true
+        File.binwrite(EltenPath.join(Dirs.eltendata, "update.last"),Zlib::Deflate.deflate(Elten.version.to_s))
+        $exit_runproc=platform_update_install_command(installer, silent: true)
+      else
+        $exit_runproc=platform_update_install_command(installer, silent: false)
+      end
     end
   end
-  end
-          rescue Hangup
+rescue Hangup
   loop_update_window
   $toscene = true
   retry
 rescue Reset
-key_update
+  key_update
   $DEBUG=true if key_held?(0x10)
   play_sound("signal") if key_held?(0x10)
   retry
 rescue SystemExit
   if $immediateexit!=true
-  loop_update
-  quit if key_held?(0x73) || mac_quit_shortcut_request
-          play_sound("listbox_focus") if $exit==nil
-  $toscene = true
+    loop_update
+    quit if key_held?(0x73) || mac_quit_shortcut_request
+    play_sound("listbox_focus") if $exit==nil
+    $toscene = true
     retry if $exit == nil
   end
 rescue Exception
   Log.error($!.class.name+": "+$!.message+" - "+$@.to_s)
   Log.error("Critical exception occurred, terminating!")
   fail
-            ensure
-            if $immediateexit!=true
-  ActivityReports.shutdown
-  NVDA.join if defined?(NVDA)
-  NVDA.destroy if defined?(NVDA)
+ensure
+  if $immediateexit!=true
+    ActivityReports.shutdown
+    NVDA.join if defined?(NVDA)
+    NVDA.destroy if defined?(NVDA)
     EltenAPI::InvisibleInterface.stop if defined?(EltenAPI::InvisibleInterface)
     Audio3DEffect.free if defined?(Audio3DEffect)
     EltenAPI::Conference.shutdown if defined?(EltenAPI::Conference)
@@ -131,56 +131,56 @@ rescue Exception
     LocalConfig.save
     FileCache.get_caches.each{|a|a.save}
     Log.debug("Closing processes")
-  if $procs!=nil  
-  for o in $procs
-terminate_process_handle(o)
+    if $procs!=nil
+      $procs.each do |o|
+        terminate_process_handle(o)
+      end
     end
-  end
-  if $exitdonotclean!=true && Dirs.temp!=nil
-  Log.info("Cleaning up temporary files")
-  FileUtils.rm_rf(Dirs.temp)
-  end
-  Log.info("Exiting Elten")
+    if $exitdonotclean!=true && Dirs.temp!=nil
+      Log.info("Cleaning up temporary files")
+      FileUtils.rm_rf(Dirs.temp)
+    end
+    Log.info("Exiting Elten")
     EltenTray.hide if defined?(EltenTray)
     if $exit_runproc!=nil
       Log.debug("Starting queued Processes")
       run($exit_runproc, false, $exit_runproc_path, false)
       exit_process(0)
-      end
     end
-    end;begin
-  rescue Exception
+  end
+end;begin
+rescue Exception
   if $updating != true and $start != nil and $downloading != true
-        speak("Critical error occurred: "+$!.message)
+    speak("Critical error occurred: "+$!.message)
     speech_wait
     sleep(0.5)
-    speak("Do you want to send the errror report?")
+    speak("Do you want to send the error report?")
     speech_wait
     if selector(["No","Yes"])== 1
       sleep(0.15)
       bug
     end
-sel = ListBox.new(["Copy error report to clipboard","Restart","Try again","Rescue mode","Abort"],header: "What to do?",index: 0,flags: ListBox::Flags::AnyDir, quiet: false)
-loop do
-  loop_update
-  sel.update
-  if key_pressed?(:key_enter)
-    if sel.index > 0
-    break
-  else
-    msg = $!.to_s+"\r\n"+$@.to_s
-    Clipboard.text=msg
-    speak("Copied to clipboard")
+    sel = ListBox.new(["Copy error report to clipboard","Restart","Try again","Rescue mode","Abort"],header: "What to do?",index: 0,flags: ListBox::Flags::AnyDir, quiet: false)
+    loop do
+      loop_update
+      sel.update
+      if key_pressed?(:key_enter)
+        if sel.index > 0
+          break
+        else
+          msg = $!.to_s+"\r\n"+$@.to_s
+          Clipboard.text=msg
+          speak("Copied to clipboard")
+        end
+      end
     end
-  end
-  end
     case sel.index
     when 1
       $toscene = false
       retry
-      when 2
-        $toscene = true
-        retry
+    when 2
+      $toscene = true
+      retry
     when 3
       speak("Rescue mode")
       speech_wait
@@ -196,25 +196,25 @@ loop do
       end
       case @sel.index
       when 0
-              fail
-        when 1
+        fail
+      when 1
         $scene = Scene_Update.new
         $toscene = true
         retry
-        when 2
-          insert_scene($scene) if $scenes != nil
-          $scene = Scene_Forum.new
-                    $toscene = true
-                    retry
-          when 3
-            insert_scene($scene) if $scenes != nil
-            $scene = Scene_Messages.new
-            $toscene = true      
-            retry
+      when 2
+        insert_scene($scene) if $scenes != nil
+        $scene = Scene_Forum.new
+        $toscene = true
+        retry
+      when 3
+        insert_scene($scene) if $scenes != nil
+        $scene = Scene_Messages.new
+        $toscene = true
+        retry
       end
-        when 4
-    fail if $DEBUG == true
-  end
+    when 4
+      fail if $DEBUG == true
+    end
   end
   if $updating == true
     retry

--- a/src/platforms/osx/eapi/speech.rb
+++ b/src/platforms/osx/eapi/speech.rb
@@ -40,7 +40,7 @@ module OSXSpeechBridge
       array = send_id(cls("NSSpeechSynthesizer"), "availableVoices")
       count = send_size(array, "count")
       result = []
-      for index in 0...count
+      (0...count).each do |index|
         voice_id = string(send_id(array, "objectAtIndex:", index, [SIZE_T]))
         attrs = send_id(cls("NSSpeechSynthesizer"), "attributesForVoice:", nsstring(voice_id), [PTR])
         name = dict_string(attrs, "NSVoiceName", "VoiceName")
@@ -513,8 +513,8 @@ module OSXSpeechBridge
 
     def interleave_samples(samples, frames, channels)
       pcm = +"".b
-      for frame in 0...frames
-        for channel in 0...channels
+      (0...frames).each do |frame|
+        (0...channels).each do |channel|
           pcm << yield(samples[channel][frame] || 0)
         end
       end

--- a/src/platforms/osx/eapi/voiceover.rb
+++ b/src/platforms/osx/eapi/voiceover.rb
@@ -1,0 +1,193 @@
+# A part of Elten - EltenLink / Elten Network desktop client.
+# Copyright (C) 2026 Dawid Pieper
+# Elten is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 3.
+
+# VoiceOver braille bridge for macOS.
+# Uses ApplicationServices AXPostNotification with kAXAnnouncementRequestedNotification
+# so that VoiceOver speaks and mirrors text on any connected Braille display.
+
+module OSXVoiceOverBridge
+  PTR  = Fiddle::TYPE_VOIDP
+  INT  = Fiddle::TYPE_INT
+  VOID = Fiddle::TYPE_VOID
+
+  class << self
+    def available?
+      app_services != nil && objc != nil
+    rescue Exception
+      false
+    end
+
+    def voiceover_running?
+      return false unless available?
+      ax_is_voiceover_enabled.call != 0
+    rescue Exception
+      false
+    end
+
+    # Send text as a VoiceOver announcement.
+    # VoiceOver will both speak it and show it on any connected Braille display.
+    def announce(text)
+      return false unless voiceover_running?
+      app_el = ax_ui_element_create_application.call(Process.pid)
+      return false if app_el.to_i == 0
+      info = build_announcement_dict(text.to_s)
+      ax_post_notification.call(app_el, nsstring("AXAnnouncementRequested"), info)
+      true
+    rescue Exception => e
+      log_warning("announce failed: #{e.class}: #{e.message}")
+      false
+    end
+
+    private
+
+    def app_services
+      return @app_services if defined?(@app_services)
+      # AppKit must be loaded first so NSObject etc. are available
+      Fiddle.dlopen("/System/Library/Frameworks/AppKit.framework/AppKit") rescue nil
+      @app_services = Fiddle.dlopen("/System/Library/Frameworks/ApplicationServices.framework/ApplicationServices")
+    rescue Exception
+      @app_services = nil
+    end
+
+    def objc
+      return @objc if defined?(@objc)
+      @objc = Fiddle.dlopen("/usr/lib/libobjc.A.dylib")
+    rescue Exception
+      @objc = nil
+    end
+
+    # --- Objective-C helpers (same pattern as OSXSpeechBridge) ---
+
+    def objc_msg_send(types, ret)
+      @objc_msg_send ||= {}
+      key = [types, ret]
+      @objc_msg_send[key] ||= Fiddle::Function.new(objc["objc_msgSend"], [PTR, PTR] + types, ret)
+    end
+
+    def objc_get_class
+      @objc_get_class ||= Fiddle::Function.new(objc["objc_getClass"], [PTR], PTR)
+    end
+
+    def sel_register_name
+      @sel_register_name ||= Fiddle::Function.new(objc["sel_registerName"], [PTR], PTR)
+    end
+
+    def cls(name)
+      objc_get_class.call(name.to_s)
+    end
+
+    def sel(name)
+      sel_register_name.call(name.to_s)
+    end
+
+    def send_id(receiver, selector, *args)
+      types = args.last.is_a?(Array) ? args.pop : Array.new(args.size, PTR)
+      objc_msg_send(types, PTR).call(receiver, sel(selector), *args)
+    end
+
+    def send_void(receiver, selector, *args)
+      types = args.last.is_a?(Array) ? args.pop : Array.new(args.size, PTR)
+      objc_msg_send(types, VOID).call(receiver, sel(selector), *args)
+    end
+
+    def nsstring(text)
+      utf8 = text.to_s.encode("UTF-8", invalid: :replace, undef: :replace)
+      send_id(cls("NSString"), "stringWithUTF8String:", utf8.b + "\0", [PTR])
+    end
+
+    def nsnumber_int(value)
+      send_id(cls("NSNumber"), "numberWithInt:", value.to_i, [INT])
+    end
+
+    # Build NSDictionary: { AXAnnouncement => text, AXPriority => 90 }
+    # AXPriority 90 = NSAccessibilityPriorityHigh (interrupts current VoiceOver output)
+    def build_announcement_dict(text)
+      keys   = ns_mutable_array([nsstring("AXAnnouncement"), nsstring("AXPriority")])
+      values = ns_mutable_array([nsstring(text), nsnumber_int(90)])
+      send_id(cls("NSDictionary"), "dictionaryWithObjects:forKeys:count:",
+              values, keys, 2, [PTR, PTR, PTR])
+    end
+
+    def ns_mutable_array(items)
+      array = send_id(cls("NSMutableArray"), "array")
+      items.each do |item|
+        send_void(array, "addObject:", item, [PTR])
+      end
+      array
+    end
+
+    # --- ApplicationServices functions ---
+
+    def ax_is_voiceover_enabled
+      @ax_is_voiceover_enabled ||= Fiddle::Function.new(
+        app_services["AXIsVoiceOverEnabled"], [], INT
+      )
+    end
+
+    def ax_ui_element_create_application
+      @ax_ui_element_create_application ||= Fiddle::Function.new(
+        app_services["AXUIElementCreateApplication"], [INT], PTR
+      )
+    end
+
+    def ax_post_notification
+      @ax_post_notification ||= Fiddle::Function.new(
+        app_services["AXPostNotification"], [PTR, PTR, PTR], INT
+      )
+    end
+
+    def log_warning(msg)
+      Log.warning("OSXVoiceOverBridge: #{msg}") if defined?(Log)
+    rescue Exception
+    end
+  end
+end
+
+# SpeechOutput subclass that provides Braille output via VoiceOver on macOS.
+# It has no speech voices – it is purely a Braille channel.
+class OSXVoiceOverOutput < SpeechOutput
+  class << self
+    def available?
+      OSXVoiceOverBridge.available?
+    rescue Exception
+      false
+    end
+
+    def usable?
+      available? && OSXVoiceOverBridge.voiceover_running?
+    rescue Exception
+      false
+    end
+
+    # Do not auto-select as speech output
+    def default?
+      false
+    end
+
+    # No speech voices – this output only handles Braille
+    def voices
+      []
+    end
+
+    def braille_supported?
+      true
+    end
+
+    def braille(_text, _pos = nil, _push = false, _type = 0, _index = nil, _cursor = nil)
+      return if Configuration.enablebraille == 0
+      return unless usable?
+      OSXVoiceOverBridge.announce(_text.to_s)
+    rescue Exception => e
+      Log.warning("OSXVoiceOverOutput.braille: #{e.class}: #{e.message}") if defined?(Log)
+    end
+
+    def braille_alert(text)
+      return if Configuration.enablebraille == 0
+      return unless usable?
+      OSXVoiceOverBridge.announce(text.to_s)
+    rescue Exception => e
+      Log.warning("OSXVoiceOverOutput.braille_alert: #{e.class}: #{e.message}") if defined?(Log)
+    end
+  end
+end

--- a/src/platforms/osx/ri/desktopruntime.rb
+++ b/src/platforms/osx/ri/desktopruntime.rb
@@ -1192,7 +1192,7 @@ module EltenKeyboard
       if !EltenWindow.keyboard_active?
         clear_state
         if buffer.respond_to?(:setbyte)
-          for key in 0..255
+          (0..255).each do |key|
             buffer.setbyte(key, 0)
           end
         end
@@ -1203,7 +1203,7 @@ module EltenKeyboard
       events = key_events
       event_flags = apply_key_events_to_state(state, events, now)
       flags = Array.new(256, 0)
-      for key in 0..255
+      (0..255).each do |key|
         down = key_down?(state, key)
         @stale_suppressed[key] = false if !down && @stale_suppressed[key] == true
         if down && stale_key_down?(key, now)
@@ -1231,10 +1231,10 @@ module EltenKeyboard
         end
         @last_down[key] = down
       end
-      for key in 0..255
+      (0..255).each do |key|
         flags[key] |= event_flags[key]
       end
-      for key in 0..255
+      (0..255).each do |key|
         buffer.setbyte(key, flags[key]) if buffer.respond_to?(:setbyte)
       end
       0
@@ -1248,7 +1248,7 @@ module EltenKeyboard
       end
       state = keyboard_state
       now = monotonic_time
-      for key in 0..255
+      (0..255).each do |key|
         down = key_down?(state, key)
         @last_down[key] = down
         @last_down_event[key] = down ? now : nil
@@ -1276,7 +1276,7 @@ module EltenKeyboard
     def active_pressed_keys
       state = raw_state
       keys = Array.new(256, false)
-      for key in 0..255
+      (0..255).each do |key|
         keys[key] = key_down?(state, key)
       end
       keys

--- a/src/platforms/windows/eapi/clipboard.rb
+++ b/src/platforms/windows/eapi/clipboard.rb
@@ -90,7 +90,7 @@ class Clipboard
         return [] if handle == nil || handle.to_i == 0
         count = native.drag_query_file.call(handle, -1, nil, 0).to_i
         files = []
-        for index in 0...count
+        (0...count).each do |index|
           length = native.drag_query_file.call(handle, index, nil, 0).to_i
           next if length <= 0
           buffer = "\0" * ((length + 1) * 2)

--- a/src/platforms/windows/eapi/nvda.rb
+++ b/src/platforms/windows/eapi/nvda.rb
@@ -115,7 +115,7 @@ SetSecurityDescriptorDacl.call(sd, 1, acl, 0)
                     end
                     @checktime=Time.now.to_f
                       b=r.split("\n")
-                      for l in b
+                      b.each do |l|
               j=JSON.load(l)
               @waiting-=1
                                          @reads[j['id']]=j
@@ -132,7 +132,7 @@ SetSecurityDescriptorDacl.call(sd, 1, acl, 0)
                                   @prepared=true
                                   end
                     b=r.split("\n")
-                      for l in b
+                      b.each do |l|
               j=JSON.load(l)
 if j['msgtype']==1
   @waiting-=1

--- a/src/platforms/windows/ri/desktopruntime.rb
+++ b/src/platforms/windows/ri/desktopruntime.rb
@@ -39,7 +39,7 @@ module EltenKeyboard
       events = key_events
       event_flags = apply_key_events_to_state(state, events, now)
       flags = Array.new(256, 0)
-      for key in 0..255
+      (0..255).each do |key|
         down = key_down?(state, key)
         @stale_suppressed[key] = false if !down && @stale_suppressed[key] == true
         if down && stale_key_down?(key, now)
@@ -71,11 +71,11 @@ module EltenKeyboard
         end
         @last_down[key] = down
       end
-      for key in 0..255
+      (0..255).each do |key|
         flags[key] |= event_flags[key]
       end
       @flags_state = state.byteslice(0, 256).to_s.dup
-      for key in 0..255
+      (0..255).each do |key|
         buffer.setbyte(key, flags[key]) if buffer.respond_to?(:setbyte)
       end
       0
@@ -85,7 +85,7 @@ module EltenKeyboard
       initialize_state
       state = keyboard_state
       now = monotonic_time
-      for key in 0..255
+      (0..255).each do |key|
         down = key_down?(state, key)
         @event_down[key] = down
         @last_down[key] = down
@@ -123,7 +123,7 @@ module EltenKeyboard
       return Array.new(256, false) if !EltenWindow.keyboard_active?
       state = raw_state
       keys = Array.new(256, false)
-      for key in 0..255
+      (0..255).each do |key|
         keys[key] = key_down?(state, key)
       end
       keys
@@ -204,7 +204,7 @@ module EltenKeyboard
           @stale_suppressed[key] = false
         end
       end
-      for key in 0..255
+      (0..255).each do |key|
         state.setbyte(key, state.getbyte(key).to_i | 0x80) if @event_down[key] == true
       end
       flags
@@ -851,7 +851,7 @@ module EltenWindow
 
     def keyboard_state_has_pressed_keys?(state)
       state = state.to_s.byteslice(0, 256).to_s.ljust(256, "\0")
-      for key in 0...256
+      (0...256).each do |key|
         return true if (state.getbyte(key).to_i & 0x80) != 0
       end
       false
@@ -915,7 +915,7 @@ module EltenWindow
     def clear_native_keyboard_state
       state = "\0" * 256
       GET_KEYBOARD_STATE.call(state)
-      for i in 0...256
+      (0...256).each do |i|
         state.setbyte(i, state.getbyte(i).to_i & 1)
       end
       SET_KEYBOARD_STATE.call(state)

--- a/src/platforms/windows/ri/win32structs.rb
+++ b/src/platforms/windows/ri/win32structs.rb
@@ -31,7 +31,7 @@ module EltenWin32
 
     def pointer_array_values(buffer, count)
       values = []
-      for i in 0...count.to_i
+      (0...count.to_i).each do |i|
         values.push(pointer_value(buffer, i * POINTER_SIZE))
       end
       values
@@ -147,7 +147,7 @@ module EltenWin32
     def bass_channel_info_values(buffer)
       filename_offset = POINTER_SIZE == 8 ? 32 : 28
       values = []
-      for i in 0...7
+      (0...7).each do |i|
         values.push(dword_value(buffer, i * 4))
       end
       values.push(pointer_value(buffer, filename_offset))

--- a/src/ri/__ri.rb
+++ b/src/ri/__ri.rb
@@ -84,7 +84,7 @@ class Array
   end    
   def to_s
     r="["
-    for i in 0...self.size
+    (0...self.size).each do |i|
       r+=", " if i>0
       r+=self[i].to_s
       end
@@ -94,7 +94,7 @@ class Array
     def shuffle
 t=self+[]      
 res=[]
-for o in t
+t.each do |o|
   v=-1
   while v==-1 or res[v]!=nil
   v=rand(t.size)
@@ -105,7 +105,7 @@ for o in t
   end
   def shuffle!
     n=shuffle
-    for i in 0..n.size-1
+    (0..n.size-1).each do |i|
       self[i]=n[i]
       end
     return self
@@ -125,7 +125,7 @@ polsorter(a,b)
   end
   def polsort!
     a=self.polsort
-    for i in 0...self.size
+    (0...self.size).each do |i|
       self[i]=a[i]
       end
     end
@@ -154,13 +154,13 @@ class String
     self.gsub!(EltenLink::LEGACY_LINE,"\r\n") if defined?(EltenLink)
     str = ""
 foundlines = 1
-    for i in 0..self.size - 1
+    (0..self.size - 1).each do |i|
       str += self[i..i]
       foundlines += 1 if self[i..i] == "\n"
     end
     fl = 0
     ret = ""
-    for i in 0..str.size - 1
+    (0..str.size - 1).each do |i|
       fl += 1 if str[i..i] == "\r" or (str[i..i] == "\n" and str[i-1..i-1] != "\r")
       if foundlines - lines > fl
         ret += str[i..i]
@@ -171,14 +171,14 @@ foundlines = 1
     def rdelete!(i)
     b = i[0]
   x = 0
-  for i in 1..self.size
+  (1..self.size).each do |i|
     if self[self.size - i] == b
       x += 1
     else
       break
     end
        end
-  for i in 0..x-1
+  (0..x-1).each do |i|
     chop!
     end
   end
@@ -228,7 +228,7 @@ string=r
     string = self+""
     from=["ą","ć","ę","ł","ń","ó","ś","ź","ż","Ą","Ć","Ę","Ń","Ó","Ł","Ś","Ź","Ż","-"]
     to=["a","c","e","l","n","o","s","z","z","A","C","E","L","N","O","S","Z","Z","_"]
-    for i in 0..to.size-1
+    (0..to.size-1).each do |i|
       string.gsub!(from[i],to[i])
       end
     r = string.gsub(/([^ a-zA-Z0-9_.-]+)/) do |m|

--- a/src/ri/nativestructs.rb
+++ b/src/ri/nativestructs.rb
@@ -31,7 +31,7 @@ module EltenNativeStructs
 
     def pointer_array_values(buffer, count)
       values = []
-      for i in 0...count.to_i
+      (0...count.to_i).each do |i|
         values.push(pointer_value(buffer, i * POINTER_SIZE))
       end
       values
@@ -75,7 +75,7 @@ module EltenNativeStructs
     def bass_channel_info_values(buffer)
       filename_offset = POINTER_SIZE == 8 ? 32 : 28
       values = []
-      for i in 0...7
+      (0...7).each do |i|
         values.push(dword_value(buffer, i * 4))
       end
       values.push(pointer_value(buffer, filename_offset))

--- a/src/scenes/account.rb
+++ b/src/scenes/account.rb
@@ -35,7 +35,7 @@ def make_setting(label, type, key, mapping=nil, multi=false)
   @settings.last.push([label, type, key, mapping, multi])
 end
 def save_category
-  for i in 2...@settings[@category].size
+  (2...@settings[@category].size).each do |i|
     setting=@settings[@category][i]
     next if setting==nil || setting[1]==:custom
     index=i-1
@@ -48,7 +48,7 @@ def save_category
     val=setting[3][val] if setting[3]!=nil
   else
     vals=[]
-    for v in field.multiselections
+    field.multiselections.each do |v|
       v=setting[3][v] if setting[3]!=nil
       vals.push(v)
     end
@@ -64,7 +64,7 @@ def show_category(id)
   @form.show_all
   @form.fields[1...-3]=[]
   f=[]
-for s in @settings[id][2..-1]
+@settings[id][2..-1].each do |s|
   label, type, key, mapping, multi = s
   field=nil
   case type
@@ -87,7 +87,7 @@ for s in @settings[id][2..-1]
       flags|=ListBox::Flags::MultiSelection if multi==true
       field=ListBox.new(type, header: label, index: index.to_i, flags: flags)
       if multi==true
-        for e in currentconfig(key).to_s.split(",")
+        currentconfig(key).to_s.split(",").each do |e|
 index=e
       index=mapping.find_index(index)||0 if mapping!=nil
       field.selected[index.to_i]=true
@@ -101,7 +101,7 @@ end
 def apply_settings
   save_category
   j={}
-  for k in @values.keys
+  @values.keys.each do |k|
     v=@values[k]
     j[k]=v
     Session.fullname=v if k=="fullname"
@@ -218,7 +218,7 @@ def load_languages
   setting_category(p_("Account", "Languages"))
   langs=[]
   langsmapping=[]
-  for lk in Lists.langs.keys.sort{|a,b|polsorter(Lists.langs[a]['name'],Lists.langs[b]['name'])}
+  Lists.langs.keys.sort{|a,b|polsorter(Lists.langs[a]['name'],Lists.langs[b]['name'])}.each do |lk|
     langsmapping.push(lk)
     l=Lists.langs[lk]
     langs.push(l['name']+"( "+l['nativeName']+")")
@@ -232,7 +232,7 @@ def load_languages
   langslabel, langstype, langskey, langsmapping, langsmulti = @settings[@category][2]
     index=0
   l=currentconfig("mainlanguage")
-  for e in @form.fields[1].multiselections
+  @form.fields[1].multiselections.each do |e|
     mainlangs.push(langstype[e])
     mainlangsmapping.push(langsmapping[e])
     index = mainlangs.size-1 if langsmapping[e]==l
@@ -263,7 +263,7 @@ def load_notifications_settings
   options=[p_("Account", "Notice and show in what's new"),p_("Account", "Notice only"),p_("Account", "Ignore")]
   cats=[p_("Account", "New messages"),p_("Account", "New posts in followed threads"),p_("Account", "New posts on the followed blogs"),p_("Account", "New comments on your blog"),p_("Account", "New threads on followed forums"),p_("Account", "New posts on followed forums"),p_("Account", "New friends"),p_("Account", "Friends' birthday"),p_("Account", "Mentions"),p_("Account", "Followed blog posts"), p_("Account", "Blog followers"), p_("Account", "Blog mentions"), p_("Account", "Awaiting group invitations")]
   sets = ["wn_messages", "wn_followedthreads", "wn_followedblogs", "wn_blogcomments", "wn_followedforums", "wn_followedforumsthreads", "wn_friends", "wn_birthday", "wn_mentions", "wn_followedblogposts", "wn_blogfollowers","wn_blogmentions", "wn_groupinvitations"]
-  for i in 0...sets.size
+  (0...sets.size).each do |i|
     make_setting(cats[i], options, sets[i])
     end
   end
@@ -420,7 +420,7 @@ end
     als=al.map { |entry| [format_date(entry.created_at, false, false), entry.ip, entry.computer] }
 selh=[p_("Account", "Computer"),p_("Account", "Creation IP Address"),p_("Account", "Generation date")]
 selt=[]
-for s in als
+als.each do |s|
   selt.push([s[2],s[1],s[0]])
 end
 @sel=TableBox.new(selh,selt,index: 0,header: p_("Account", "Auto log in tokens"), quiet: false)
@@ -571,7 +571,7 @@ loop_update
     lgs=lg.map { |entry| [format_date(entry.created_at, false, false), entry.ip] }
 selh=["",""]
 selt=[]
-for s in lgs
+lgs.each do |s|
   selt.push([s[0],s[1]])
 end
 @sel=TableBox.new(selh,selt,index: 0,header: p_("Account", "Last logins"), quiet: false)

--- a/src/scenes/admins.rb
+++ b/src/scenes/admins.rb
@@ -25,7 +25,7 @@ class Scene_Admins
       if subcat==0
         ld=loadedlanguages
         i=0
-      for lo in ld
+      ld.each do |lo|
         l=lo.mo
         lang=Lists.langs[lo.realcode[0..1].downcase]['name']
                             @selt.push(lang)
@@ -69,7 +69,7 @@ class Scene_Admins
       return main(0) if cat > 0
       return
     end
-      for i in 0...@users.size
+      (0...@users.size).each do |i|
         @selt[i]=user_with_status(@users[i], true, true, "\r\n")
         end
     h=""

--- a/src/scenes/blog.rb
+++ b/src/scenes/blog.rb
@@ -115,7 +115,7 @@ rescue EltenLink::Error
 end
 @blogname=blogname=blogtemp.name
 @categories = []
-for c in blogtemp.categories
+blogtemp.categories.each do |c|
   @categories.push(c)  if @isowner or c.posts>0
 end
 sel = [[p_("Blog", "All posts"), nil]] + @categories.map{|c|[c.name, c.posts.to_s]}
@@ -276,7 +276,7 @@ class Scene_Blog_Posts
       rescue EltenLink::Error
         mnts=[]
       end
-        for source in mnts
+        mnts.each do |source|
           mention=Struct_Blog_Mention.new
           mention.id=source.id
           mention.blog=source.blog
@@ -295,7 +295,7 @@ class Scene_Blog_Posts
 if @topage==0
         load_posts(@page)
       else
-        for i in 1..@topage
+        (1..@topage).each do |i|
           load_posts(i)
         end
         @page=@topage
@@ -362,7 +362,7 @@ rescue EltenLink::Error
 end
 post=nil
 @post = [] if @id == "NEWFOLLOWEDBLOGS"
-for source in blogtemp.posts
+blogtemp.posts.each do |source|
   post=Struct_Blog_Post.new(source.id)
   post.name = source.name
     post.unread=source.unread
@@ -375,7 +375,7 @@ for source in blogtemp.posts
   post.comments=source.comments
   post.followed=source.followed
   if @id=="MENTIONED" or @id=="NEWMENTIONED"
-    for mention in @mentions
+    @mentions.each do |mention|
       if mention.blog==post.owner && mention.postid==post.id
         post.mention=mention
         @post.push(post.clone)
@@ -585,7 +585,7 @@ end
 @postcur = 0
 @fields = []
 fdate=""
-for i in 0..@posts.size-1
+(0..@posts.size-1).each do |i|
 field_index=(i==0?i:(i+2))
 @fields[field_index] = EditBox.new(@posts[i].author,type: EditBox::Flags::MultiLine|EditBox::Flags::ReadOnly|EditBox::Flags::HTML,text: format(@posts[i]),quiet: true)
 @fields[field_index].audio_url=@posts[i].audio_url if @posts[i].audio_url.to_s!="" && @posts[i].text.to_s.delete(" \r\n")==""
@@ -900,7 +900,7 @@ def refresh
     rescue EltenLink::Error
       return
     end
-    for source in bt
+    bt.each do |source|
       b=Struct_Blog_Blog.new
       b.id=source.id
       b.library_user = source.library_user
@@ -961,7 +961,7 @@ if @scene!=nil && items==0
   $scene=@scene
   return
   end
-for source in blogtemp
+blogtemp.each do |source|
   b=Struct_Blog_Blog.new
   b.id=source.id
   b.name=source.name
@@ -975,7 +975,7 @@ for source in blogtemp
   b.elten=true
     @blogs.push(b) if LocalConfig["BlogShowUnknownLanguages",1]==1 || knownlanguages.size==0 || knownlanguages.include?(b.lang[0..1].upcase) || (@type.is_a?(String) || @type==3)
 end
-for b in @blogs
+@blogs.each do |b|
   bo=blogowners(b.id)
   bo=[bo] if bo.is_a?(String)
   b.owners=bo
@@ -992,7 +992,7 @@ def addlib(blog)
     langs=[]
   langsmapping=[]
   lnindex=0
-  for lk in Lists.langs.keys.sort{|a,b|polsorter(Lists.langs[a]['name'],Lists.langs[b]['name'])}
+  Lists.langs.keys.sort{|a,b|polsorter(Lists.langs[a]['name'],Lists.langs[b]['name'])}.each do |lk|
     langsmapping.push(lk)
     l=Lists.langs[lk]
     langs.push(l['name']+"( "+l['nativeName']+")")
@@ -1325,9 +1325,9 @@ blogtemp.posts.each_with_index do |post, i|
   @postcategories[i]=post.categories.to_a
 end
 @fields=[]
-for i in 0..@postid.size-1
+(0..@postid.size-1).each do |i|
   f=ListBox.new(categorynames,header: @postname[i],index: 0,flags: ListBox::Flags::MultiSelection)
-  for c in @postcategories[i]
+  @postcategories[i].each do |c|
     ind=categoryids.find_index(c)
     f.selected[ind]=true if ind!=nil
     end
@@ -1341,17 +1341,17 @@ loop do
   break if key_pressed?(:key_escape) or ((key_pressed?(:key_space) or key_pressed?(:key_enter)) and @form.index==@form.fields.size-1)
   if (key_pressed?(:key_space) or key_pressed?(:key_enter)) and (@form.index==@form.fields.size-2 or key_held?(0x11))
     ou=""
-for i in 0..@postid.size-1
+(0..@postid.size-1).each do |i|
   ch=[]
-  for j in 0..@form.fields[i].selected.size-1
+  (0..@form.fields[i].selected.size-1).each do |j|
     ch.push(categoryids[j]) if @form.fields[i].selected[j]==true
   end
   ou+=@postid[i].to_s+":"+ch.join(",")+"|" if ch.size>0
 end
 begin
-  for i in 0..@postid.size-1
+  (0..@postid.size-1).each do |i|
     ch=[]
-    for j in 0..@form.fields[i].selected.size-1
+    (0..@form.fields[i].selected.size-1).each do |j|
       ch.push(categoryids[j]) if @form.fields[i].selected[j]==true
     end
     EltenLink::Blog.update_post(elten_link, blog: @searchname, post_id: @postid[i], categories: ch)
@@ -1387,7 +1387,7 @@ class Scene_Blog_Post_Move
       $scene=Scene_Main.new
       return
       end
-            for blog in b
+            b.each do |blog|
         @blogids.push(blog.id)
         @blognames.push(blog.name)
       end
@@ -1459,7 +1459,7 @@ def make_setting(label, type, key, mapping=nil)
   @settings.last.push([label, type, key, mapping])
 end
 def save_category
-  for i in 2...@settings[@category].size
+  (2...@settings[@category].size).each do |i|
     setting=@settings[@category][i]
     next if setting==nil || setting[1]==:custom
     index=i-1
@@ -1479,7 +1479,7 @@ def show_category(id)
   @form.show_all
   @form.fields[1...-3]=[]
   f=[]
-for s in @settings[id][2..-1]
+@settings[id][2..-1].each do |s|
   label, type, key, mapping = s
   field=nil
   case type
@@ -1507,7 +1507,7 @@ end
 def apply_settings
   save_category
   j={}
-  for k in @values.keys
+  @values.keys.each do |k|
     v=@values[k]
     j[k]=v
   end
@@ -1532,7 +1532,7 @@ def load_general
   langs=[]
   langsmapping=[]
   getconfig if @languages==nil
-  for lang in @languages.keys
+  @languages.keys.each do |lang|
     l=@languages[lang]
     langsmapping.push(lang)
     langs.push(l['english_name']+"("+l['native_name']+")")
@@ -1633,7 +1633,7 @@ def load_date
     timezones=[]
   timezonesmapping=[]
   getconfig if @timezones==nil
-for k in @timezones.keys
+@timezones.keys.each do |k|
   timezones.push(@timezones[k])
   timezonesmapping.push(k)
 end
@@ -1653,7 +1653,7 @@ def load_others
   blogs=get_blogs
   b=[p_("Blog", "Do not set")]
   bm=[""]
-    for bl in blogs
+    blogs.each do |bl|
     if bl.url!="https://"+@domain+"/"
     b.push(bl.name+" ("+bl.url+")")
     bm.push(bl.url)
@@ -1696,7 +1696,7 @@ else
             return []
           end
 blogs=[]
-for source in blogtemp
+blogtemp.each do |source|
   b=Struct_Blog_Blog.new
   b.id=source.id
   b.name=source.name
@@ -1817,7 +1817,7 @@ class Scene_Blog_Tags
       return $scene=Scene_Main.new
     end
     @tags=[]
-    for source in bt
+    bt.each do |source|
       @tags.push(Struct_Blog_Tag.new(source.id))
       @tags.last.name=source.name
     end
@@ -1892,7 +1892,7 @@ class Scene_Blog_PostEditor
       return $scene=Scene_Main.new
     end
     @categories = []
-    for source in bt.categories
+    bt.categories.each do |source|
       c=Struct_Blog_Category.new
       c.id=source.id
       c.name=source.name
@@ -1906,7 +1906,7 @@ class Scene_Blog_PostEditor
       return $scene=Scene_Main.new
     end
     @tags= []
-    for source in bt
+    bt.each do |source|
       t=Struct_Blog_Tag.new
       t.id=source.id
       t.name=source.name
@@ -1933,7 +1933,7 @@ lst_tags.bind_context{|menu|
           dialog_open
         tag = selecttag
           dialog_close
-          for t in @tags
+          @tags.each do |t|
             if tag != nil and t.name.downcase == tag.name.downcase
               tagid = t.id
               break
@@ -1949,7 +1949,7 @@ menu.option(p_("Blog", "Add tag to this post"), nil, "n") {
 tagname=input_text(p_("Blog", "Tag to add"), flags: 0, text: "", escapable: true)
 if tagname!=nil
 tagid=-1
-for t in @tags
+@tags.each do |t|
   if t.name.downcase==tagname.downcase
     tagid=t.id
     break
@@ -1981,7 +1981,7 @@ end
 changed=false
 edt_post.on(:delete) {changed=true}
 edt_post.on(:insert) {changed=true}
-for i in 0...@categories.size
+(0...@categories.size).each do |i|
   lst_categories.selected[i] = true if @categories[i].id == @category
 end
 if @post>0
@@ -2019,11 +2019,11 @@ ph = EltenLink::Client.absolute_api_url(ph)
     edt_excerpt.set_text(excerpt)
     chk_comments.checked=comments
     lst_visibility.index=privacy
-    for i in 0...@categories.size
+    (0...@categories.size).each do |i|
       lst_categories.selected[i]=(cats.include?(@categories[i].id))
     end
-    for tagid in tags
-      for tag in @tags
+    tags.each do |tagid|
+      @tags.each do |tag|
         if tag.id==tagid
           @tagids.push(tagid)
           lst_tags.options.push(tag.name)
@@ -2094,7 +2094,7 @@ end
         text = edt_post.text
         end
 cats=[]
-for i in 0...@categories.size
+(0...@categories.size).each do |i|
   cats.push(@categories[i].id) if lst_categories.selected[i]==true
 end
 if suc
@@ -2270,7 +2270,7 @@ if suc
         return
       end
         @comments.clear
-        for source in ct
+        ct.each do |source|
             @comments.push(Struct_Blog_Comment.new)
             @comments.last.id=source.id
               @comments.last.author=source.author
@@ -2279,7 +2279,7 @@ if suc
             end
             @sel.rows=nil
             r=[]
-            for c in @comments
+            @comments.each do |c|
               r.push([c.author, c.postname, c.content])
             end
             @sel.rows=r
@@ -2318,7 +2318,7 @@ end
   users=[]
   blogs=[]
   blognames=[]
-  for source in b
+  b.each do |source|
     blogs.push(source.blog)
     blognames.push(source.blog_name)
     users.push(source.user)
@@ -2327,7 +2327,7 @@ end
     alert(p_("Blog", "This blog is not followed by any user"))
   else
     rows=[]
-    for i in 0...b.size
+    (0...b.size).each do |i|
       rows.push([users[i], blognames[i]])
     end
     head=p_("Blog", "Followers")

--- a/src/scenes/changes.rb
+++ b/src/scenes/changes.rb
@@ -142,7 +142,7 @@ verdots=v[0].delete(".").split("").join(".")
 }
 @changes.reverse!
 @selt = []
-for i in 0..@changes.size - 1
+(0..@changes.size - 1).each do |i|
   @selt.push((@changes[i]).split("\n")[0].delete(":").sub(verstring+" ",""))
   end
 @sel = ListBox.new(@selt,header: p_("Changes", "Changelog"), index: 0, flags: 0, quiet: false)

--- a/src/scenes/clock.rb
+++ b/src/scenes/clock.rb
@@ -12,7 +12,7 @@ class Scene_Clock
               @field[2]=Button.new(_("Cancel"))
               @alarms=EltenAPI::Alarms.load.map{|alarm| alarm.dup}
               sel=[]
-              for a in @alarms
+              @alarms.each do |a|
                   sel.push("#{p_("Clock","Hour")}: #{sprintf("%02d:%02d",a[0],a[1])}, #{p_("Clock","Type")}: #{if a[2]==0;p_("Clock", "One time");else;p_("Clock", "repeated");end}")
                 end
                 @field[0].options=sel
@@ -91,7 +91,7 @@ refresh
                                                                            end
                                                                            def refresh
                                                                                                                                                         sel=[]
-                                                                           for a in @alarms
+                                                                           @alarms.each do |a|
                                                                                sel.push("#{p_("Clock","Hour")}: #{sprintf("%02d:%02d",a[0],a[1])}, #{p_("Clock","Type")}: #{if a[2]==0;p_("Clock", "One time");else;p_("Clock", "Repeated");end}: #{(a[3]!=nil)?a[3]:""}")
                                                                              end
                                                                              @field[0].options=sel 

--- a/src/scenes/conference.rb
+++ b/src/scenes/conference.rb
@@ -72,7 +72,7 @@ class Scene_Conference
             }
             end
           menu.option(p_("Conference", "Deny speech to all users"), nil, "_") {
-          for u in Conference.channel.users  
+          Conference.channel.users.each do |u|
             if !Conference.channel.administrators.include?(u.name)
           Conference.speech_deny(u.id)
           end
@@ -211,7 +211,7 @@ end
     timeout_break if Conference.channel.users.size>1
             lst_users.clear_options
         ind=nil
-            for u in Conference.channel.users
+            Conference.channel.users.each do |u|
           parts=[u.name]
           if u.supervisor!=nil && u.supervisor!=""
           su=Conference.channel.users.find{|us|us.id==u.supervisor}
@@ -258,7 +258,7 @@ end
     @users_hook.block.call
     @text_hook = Conference.on(:text) {
 options=[]
-    for c in Conference.texts
+    Conference.texts.each do |c|
 if c[2].is_a?(String)
   ch=c[0]+": "+c[2]
   ch=ch[0...5000]
@@ -554,7 +554,7 @@ if channel==nil
 [p_("Conference", "Low quality"), 28, 60, 1, 2, 0, 0, 1],
 ]
 prindex=presets.size
-for preset in presets
+presets.each do |preset|
   if channel.bitrate==preset[1] and channel.framesize==preset[2] and channel.channels==preset[3] and channel.vbr_type==preset[4] and channel.codec_application==preset[5] and channel.spatialization==preset[6] and ((channel.fec)?(1):(0))==preset[7] and channel.prediction_disabled==false
     prindex=presets.find_index(preset)
     end
@@ -563,7 +563,7 @@ for preset in presets
     langs = []
       langnames=[]
     lnindex = 0
-    for lk in Lists.langs.keys
+    Lists.langs.keys.each do |lk|
       l = Lists.langs[lk]
       if (channel.groupid==0 || channel.groupid==nil) || channel.lang.downcase[0..1]==lk.downcase[0..1]
       langnames.push(l["name"] + " (" + l["nativeName"] + ")")
@@ -682,7 +682,7 @@ chk_hidden = CheckBox.new(p_("Conference", "Make this channel hidden"), checked:
   lst_preset.trigger(:move)  
   lst_bitrate.on(:move) {
     bitrate=bitrates[lst_bitrate.index]
-          for i in 0...framesizes.size
+          (0...framesizes.size).each do |i|
             c=framesizes[i]*bitrates[lst_bitrate.index]/8*1000/1024
         if c>1280 || c<=5
           lst_framesize.disable_item(i)
@@ -952,7 +952,7 @@ end
 def generate_pushtotalkkeyslabel
   kb=[]
   ks=Conference.pushtotalk_keys
-  for k in ks.sort
+  ks.sort.each do |k|
   case k
   when 0x10
     kb.push("SHIFT")
@@ -1018,7 +1018,7 @@ form=Form.new([
     lst_modifiers.selected[6]=ks.include?(0x1a)
   lst_modifiers.selected[7]=ks.include?(0xA3)
   lst_modifiers.selected[8]=ks.include?(0xA5)
-  for k in ks
+  ks.each do |k|
     if keys.include?(k)
       lst_key.index=keys.find_index(k)
       break
@@ -1096,18 +1096,18 @@ timeout_break
     menu.option(p_("Conference", "Channel scenery"), nil, "o") {chanobjects}
     cardset = false
    cardset = true if Conference.mystreams.sources.find{|s|!s.scrollable}!=nil
-for s in Conference.mystreams.streams
+Conference.mystreams.streams.each do |s|
   cardset = true if s.sources.find{|s|!s.scrollable}!=nil
   end
     if cardset
 menu.option(p_("Conference", "Remove soundcard stream")) {
 td=[]
-for i in 0...Conference.mystreams.sources.size
+(0...Conference.mystreams.sources.size).each do |i|
   td.push(i) if !Conference.mystreams.sources[i].scrollable
 end
 td.reverse.each{|q|Conference.removesource(-1, q)}
 td=[]
-for i in 0...Conference.mystreams.streams.size
+(0...Conference.mystreams.streams.size).each do |i|
   td.push(i) if Conference.mystreams.streams[i].sources.find{|s|!s.scrollable}!=nil
 end
 td.reverse.each{|q|Conference.stream_remove(q)}
@@ -1123,7 +1123,7 @@ chk_listen = CheckBox.new(p_("Conference", "Turn on the listening"), checked: tr
 btn_cardok = Button.new(p_("Conference", "Stream")),
 btn_cardcancel = Button.new(_("Cancel"))
 ], index: 0, silent: false, quiet: true)
-for i in 0...mics.size
+(0...mics.size).each do |i|
   lst_card.disable_item(i) if mics[i].disabled?
   end
 btn_cardcancel.on(:press) {form.resume}
@@ -1143,18 +1143,18 @@ if cardid>-1
 end
 streaming = false
 streaming = true if Conference.mystreams.sources.find{|s|s.scrollable}!=nil
-for s in Conference.mystreams.streams
+Conference.mystreams.streams.each do |s|
   streaming = true if s.sources.find{|s|s.scrollable}!=nil
   end
 if streaming
 menu.option(p_("Conference", "Remove audio stream"), nil, "i") {
 td=[]
-for i in 0...Conference.mystreams.sources.size
+(0...Conference.mystreams.sources.size).each do |i|
   td.push(i) if Conference.mystreams.sources[i].scrollable
 end
 td.reverse.each{|q|Conference.removesource(-1, q)}
 td=[]
-for i in 0...Conference.mystreams.streams.size
+(0...Conference.mystreams.streams.size).each do |i|
   td.push(i) if Conference.mystreams.streams[i].sources.find{|s|s.scrollable}!=nil
 end
 td.reverse.each{|q|Conference.stream_remove(q)}
@@ -1247,7 +1247,7 @@ def context(menu)
   if Conference.channel.conference_mode==1
     allowed=false
 requested=false
-    for u in Conference.channel.users
+    Conference.channel.users.each do |u|
   if u.id==Conference.userid
     allowed=true if u.speech_allowed
     requested=true if u.speech_requested
@@ -1680,19 +1680,19 @@ sel.focus
   end
   if sources.find{|s|s.toggleable}!=nil
   menu.option(p_("Conference", "Toggle stream"), nil, "p") {
-  for i in 0...sources.size
+  (0...sources.size).each do |i|
     Conference.togglestream(sid, i) if sources[i].toggleable
     end
   }
   end
   if sources.find{|s|s.scrollable}!=nil
     menu.option(p_("Conference", "Scroll backward"), nil, "[") {
-  for i in 0...sources.size
+  (0...sources.size).each do |i|
     Conference.scrollstream(-5, sid, i) if sources[i].toggleable
     end
   }
   menu.option(p_("Conference", "Scroll forward"), nil, "]") {
-  for i in 0...sources.size
+  (0...sources.size).each do |i|
     Conference.scrollstream(5, sid, i) if sources[i].toggleable
     end
   }
@@ -1782,7 +1782,7 @@ lst_location = ListBox.new([p_("Conference", "Right next to me"), p_("Conference
 btn_place = Button.new(p_("Conference", "Place")),
 btn_cancel = Button.new(_("Cancel"))
 ], index: 0, silent: false, quiet: true)
-for i in 0...mics.size
+(0...mics.size).each do |i|
   lst_card.disable_item(i) if mics[i].disabled?
   end
 btn_place.on(:press) {
@@ -1930,7 +1930,7 @@ lst_card = ListBox.new(mics.map{|m|o="";o=" ("+p_("Conference", "Loopback device
 btn_place = Button.new(p_("Conference", "Place")),
 btn_cancel = Button.new(_("Cancel"))
 ], index: 0, silent: false, quiet: true)
-for i in 0...mics.size
+(0...mics.size).each do |i|
   lst_card.disable_item(i) if mics[i].disabled?
   end
 btn_place.on(:press) {
@@ -1985,7 +1985,7 @@ class Scene_Conference_VSTS
     rfr=Proc.new {
     selt=[]
     if vst!=nil
-    for param in vst['parameters']
+    vst['parameters'].each do |param|
       selt.push([param['name'], param['unit'], param['display'], param['value'].to_s])
     end
     end
@@ -2067,7 +2067,7 @@ class Scene_Conference_VSTS
     @vsts=Conference.vsts(@userid)
     selt=[]
     if @vsts!=nil
-      for v in @vsts
+      @vsts.each do |v|
         selt.push([v['name'], v['bypass']?(p_("Conference", "Disabled")):p_("Conference", "Enabled"), v['file']])
         end
     end
@@ -2152,7 +2152,7 @@ t=File.file?(vstchains_file) ? File.binread(vstchains_file) : "".b
 t+=[name.bytesize].pack("I")
 t+=name
 t+=[@vsts.size].pack("I")
-for i in 0...@vsts.size
+(0...@vsts.size).each do |i|
   v=@vsts[i]
   t+=[v['file'].bytesize].pack("I")
 t+=v['file']
@@ -2260,7 +2260,7 @@ menu.option(p_("Conference", "Add VST"), nil, "n") {
          return if hd[3]!=1
          return if hd[4]!=@vsts[@sel.index]['uniqueid']
        params=f.unpack("g*")
-       for i in 0...params.size
+       (0...params.size).each do |i|
          break if i>=@vsts[@sel.index]['parameters'].size
          Conference.vst_setparam(@sel.index, i, params[i], @userid)
          end
@@ -2280,7 +2280,7 @@ menu.option(p_("Conference", "Add VST"), nil, "n") {
          name=io.read(sz)
                   vsz=io.read(4).unpack("I").first
                   vsts=[]
-                  for i in 0...vsz
+                  (0...vsz).each do |i|
         sz=io.read(4).unpack("I").first
                     file=io.read(sz)
                     sz=io.read(4).unpack("I").first
@@ -2293,11 +2293,11 @@ menu.option(p_("Conference", "Add VST"), nil, "n") {
  end
  save = Proc.new {
  wr=""
- for c in chains
+ chains.each do |c|
    wr+=[c[0].bytesize].pack("I")
    wr+=c[0]
    wr+=[c[1].size].pack("I")
-   for v in c[1]
+   c[1].each do |v|
 wr+=[v[0].bytesize].pack("I")
    wr+=v[0]
      wr+=[v[1].to_s.bytesize].pack("I")
@@ -2340,7 +2340,7 @@ wr+=[v[0].bytesize].pack("I")
        Conference.vst_remove(0, @userid)
 refresh
        end
-     for v in chain[1]
+     chain[1].each do |v|
      Conference.vst_add(v[0], @userid)
       refresh  
      if v[1]!=nil

--- a/src/scenes/contacts.rb
+++ b/src/scenes/contacts.rb
@@ -36,7 +36,7 @@ class Scene_Contacts
         alert(p_("Contacts", "Empty list"))
               end
       selt = []
-      for i in 0..@contact.size - 1
+      (0..@contact.size - 1).each do |i|
         selt[i] = user_with_status(@contact[i])
         end
       header=p_("Contacts", "Contacts")

--- a/src/scenes/feedviewer.rb
+++ b/src/scenes/feedviewer.rb
@@ -102,10 +102,10 @@ dialog_close
     users=[feed.user]
     users+=feed.message.scan(/\@([a-zA-Z0-9\.\-\_]+)/).map{|r|r[0]}
     todel=[]
-    for u in users
+    users.each do |u|
       todel.push(u) if u.downcase==Session.name.downcase
     end
-    for i in 1...users.size
+    (1...users.size).each do |i|
       todel.push(users[i]) if users[0...i].map{|u|u.downcase}.include?(users[i].downcase)
       end
     todel.each{|u|users.delete(u)}

--- a/src/scenes/forum.rb
+++ b/src/scenes/forum.rb
@@ -105,11 +105,11 @@ elsif @preparam.is_a?(String)
         foll = true if @preparam == -5
         @frmindex = 0
         forum = nil
-        for thread in @threads
+        @threads.each do |thread|
           forum = thread.forum.name if thread.id == @pre
         end
         group = nil
-        for tforum in @forums
+        @forums.each do |tforum|
           group = tforum.group.id if tforum.name == forum
         end
         group = -5 if @preparam == -5
@@ -117,7 +117,7 @@ elsif @preparam.is_a?(String)
         @grpsetindex = group if group > 0
         @grpindex[0] = 1 if @preparam == -5
         i = 0
-        for tforum in @forums
+        @forums.each do |tforum|
           if (tforum.group.id == group) or (tforum.followed and @preparam == -5)
             @frmindex = i if tforum.name == forum
             i += 1
@@ -203,7 +203,7 @@ break
       sgloc = false
       klangs=[]
       knownlanguages = Session.languages.split(",").map{|lg|lg.upcase}
-      for g in @groups
+      @groups.each do |g|
         if g.role == 1 || g.role == 2
           @sgroups.push(g)
         end
@@ -215,7 +215,7 @@ break
       end
             @sgroups += spgroups
             sorts=(0..@groups.map{|g|g.id}.max||0).to_a.map{0}
-      for t in @threads
+      @threads.each do |t|
         g=t.forum.group.id
         sorts[g]=t.lastupdate if sorts[g]<t.lastupdate
           end
@@ -232,7 +232,7 @@ break
       }
       @grpheadindex = 3
       grpselt = []
-      for i in 0...@sgroups.size
+      (0...@sgroups.size).each do |i|
         group = @sgroups[i]
         grpselt.push([group.name, group.forums.to_s, group.threads.to_s, group.posts.to_s, (group.posts - group.readposts).to_s])
         @grpindex[0] = i + @grpheadindex if group.id == @grpsetindex
@@ -241,7 +241,7 @@ break
             flt = flr = flp = 0
       ft = fp = fr = 0
       fmt=fmp=fmr=0
-      for thread in @threads
+      @threads.each do |thread|
         if thread.followed
           ft += 1
           fp += thread.posts
@@ -285,7 +285,7 @@ break
       @grpindex[0] = @grpheadindex + @sgroups.size + ll - 1 if ll > 0
       when       1 #Recently active
               @sgroups = []
-      for g in @groups
+      @groups.each do |g|
         next if LocalConfig['ForumShowUnknownLanguages']==0 && knownlanguages.size>0 && !knownlanguages.include?(g.lang[0..1].upcase)
         next if g.hidden
         if (g.public || g.open) && g.posts > 0
@@ -293,7 +293,7 @@ break
         end
       end
       sorts=(0..@groups.map{|g|g.id}.max||0).to_a.map{0}
-      for t in @threads
+      @threads.each do |t|
         g=t.forum.group.id
         sorts[g]=t.lastupdate if sorts[g]<t.lastupdate
           end
@@ -303,14 +303,14 @@ break
       }
       @grpheadindex = 0
       grpselt = []
-      for group in @sgroups
+      @sgroups.each do |group|
         grpselt.push([group.name, group.founder, group.description, group.forums.to_s, group.threads.to_s, group.posts.to_s, (group.posts - group.readposts).to_s])
       end
       grpselh = [nil, p_("Forum", "Administrator"), nil, p_("Forum", "Forums"), p_("Forum", "Threads"), p_("Forum", "posts"), p_("Forum", "Unread")]
     when 2 #Recommended
       @sgroups = []
       spgroups = []
-      for g in @groups
+      @groups.each do |g|
         next if LocalConfig['ForumShowUnknownLanguages']==0 && knownlanguages.size>0 && !knownlanguages.include?(g.lang[0..1].upcase)
         if g.recommended
           if Configuration.language[0..1].downcase == g.lang.downcase
@@ -324,13 +324,13 @@ break
       @sgroups.sort {|a,b| groupsorter(a,b)} if LocalConfig["ForumSort"]!=0
       @grpheadindex = 0
       grpselt = []
-      for group in @sgroups
+      @sgroups.each do |group|
         grpselt.push([group.name + ": " + group.description, group.forums.to_s, group.threads.to_s, group.posts.to_s, (group.posts - group.readposts).to_s])
       end
       grpselh = [nil, p_("Forum", "Forums"), p_("Forum", "Threads"), p_("Forum", "posts"), p_("Forum", "Unread")]
     when 3 #Open
       @sgroups = []
-      for g in @groups
+      @groups.each do |g|
         next if LocalConfig['ForumShowUnknownLanguages']==0 && knownlanguages.size>0 && !knownlanguages.include?(g.lang[0..1].upcase)
         next if g.hidden
         if g.open && g.public && !g.recommended && g.posts > 0
@@ -346,13 +346,13 @@ break
       }
       @grpheadindex = 0
       grpselt = []
-      for group in @sgroups
+      @sgroups.each do |group|
         grpselt.push([group.name, group.founder, group.description, group.forums.to_s, group.threads.to_s, group.posts.to_s, (group.posts - group.readposts).to_s])
       end
       grpselh = [nil, p_("Forum", "Administrator"), nil, p_("Forum", "Forums"), p_("Forum", "Threads"), p_("Forum", "posts"), p_("Forum", "Unread")]
     when 4 #Invited
       @sgroups = []
-      for g in @groups
+      @groups.each do |g|
         if g.role == 5
           @sgroups.push(g)
         end
@@ -366,13 +366,13 @@ break
       }
       @grpheadindex = 0
       grpselt = []
-      for group in @sgroups
+      @sgroups.each do |group|
         grpselt.push([group.name, group.founder, group.description, group.forums.to_s, group.threads.to_s, group.posts.to_s, (group.posts - group.readposts).to_s])
       end
       grpselh = [nil, p_("Forum", "Administrator"), nil, p_("Forum", "Forums"), p_("Forum", "Threads"), p_("Forum", "posts"), p_("Forum", "Unread")]
     when 5 #Moderated
       @sgroups = []
-      for g in @groups
+      @groups.each do |g|
         if g.role == 2
           @sgroups.push(g)
         end
@@ -386,13 +386,13 @@ break
         }
       @grpheadindex = 0
       grpselt = []
-      for group in @sgroups
+      @sgroups.each do |group|
         grpselt.push([group.name, group.founder, group.forums.to_s, group.threads.to_s, group.posts.to_s, (group.posts - group.readposts).to_s])
       end
       grpselh = [nil, p_("Forum", "Administrator"), p_("Forum", "Forums"), p_("Forum", "Threads"), p_("Forum", "posts"), p_("Forum", "Unread")]
     when 6 #All
       @sgroups = []
-      for g in @groups
+      @groups.each do |g|
         next if LocalConfig['ForumShowUnknownLanguages']==0 && knownlanguages.size>0 && !knownlanguages.include?(g.lang[0..1].upcase)
         if g.forums > 0
           @sgroups.push(g)
@@ -407,13 +407,13 @@ break
       }
       @grpheadindex = 0
       grpselt = []
-      for group in @sgroups
+      @sgroups.each do |group|
         grpselt.push([group.name, group.founder, group.description, group.forums.to_s, group.threads.to_s, group.posts.to_s, (group.posts - group.readposts).to_s])
       end
       grpselh = [nil, p_("Forum", "Administrator"), nil, p_("Forum", "Forums"), p_("Forum", "Threads"), p_("Forum", "posts"), p_("Forum", "Unread")]
     when 7 #Recently created
       @sgroups = []
-      for g in @groups
+      @groups.each do |g|
         next if LocalConfig['ForumShowUnknownLanguages']==0 && knownlanguages.size>0 && !knownlanguages.include?(g.lang[0..1].upcase)
         next if g.hidden
         if g.forums > 0
@@ -423,14 +423,14 @@ break
       @sgroups.sort! { |a, b| b.created<=> a.created}
       @grpheadindex = 0
       grpselt = []
-      for group in @sgroups
+      @sgroups.each do |group|
         grpselt.push([group.name, group.founder, group.description, group.forums.to_s, group.threads.to_s, group.posts.to_s, (group.posts - group.readposts).to_s])
       end
       grpselh = [nil, p_("Forum", "Administrator"), nil, p_("Forum", "Forums"), p_("Forum", "Threads"), p_("Forum", "posts"), p_("Forum", "Unread")]
     when 8 #Popular
       grp = forum_fetch([], nil) { EltenLink::Forum.popular_groups(elten_link) }
       @sgroups = []
-        for l in grp
+        grp.each do |l|
           g = nil
           @groups.each { |r| g = r if r.id == l.to_i }
           if g!=nil
@@ -441,13 +441,13 @@ break
         end
       @grpheadindex = 0
       grpselt = []
-      for group in @sgroups
+      @sgroups.each do |group|
         grpselt.push([group.name, group.founder, group.description, group.forums.to_s, group.threads.to_s, group.posts.to_s, (group.posts - group.readposts).to_s])
       end
       grpselh = [nil, p_("Forum", "Administrator"), nil, p_("Forum", "Forums"), p_("Forum", "Threads"), p_("Forum", "posts"), p_("Forum", "Unread")]
     end
     if @grpindex[type] == nil and @grpsetindex != nil
-      for i in 0...@sgroups.size
+      (0...@sgroups.size).each do |i|
         @grpindex[type] = i + @grpheadindex if @sgroups[i].id == @grpsetindex
       end
     end
@@ -607,7 +607,7 @@ return result
         szs = forum_fetch([], nil) { EltenLink::Forum.group_size(elten_link, group_id: g.id) }
         if szs.size >= 3
           s += p_("Forum", "Group size") + "\n"
-          for i in 0..3
+          (0..3).each do |i|
             if i < 3
               a = szs[i].to_i
             else
@@ -721,10 +721,10 @@ if (((@sgroups[@grpsel.index - @grpheadindex].role==1 || (@sgroups[@grpsel.index
           if forum_attempt(nil) {
             EltenLink::Forum.mark_group_as_read(elten_link, group_id: @sgroups[@grpsel.index-@grpheadindex].id)
           }
-            for t in @threads
+            @threads.each do |t|
               t.readposts = t.posts if t.forum.group.id == @sgroups[@grpsel.index-@grpheadindex].id
             end
-            for f in @forums
+            @forums.each do |f|
               f.readposts=f.posts if f.group.id==@sgroups[@grpsel.index-@grpheadindex].id
               end
             @sgroups[@grpsel.index-@grpheadindex].readposts = @sgroups[@grpsel.index-@grpheadindex].posts
@@ -1052,7 +1052,7 @@ rfr=Proc.new {
       users = []
       roles = []
       inherits=[]
-      for member in members
+      members.each do |member|
         users.push(member.user)
         roles.push(member.role)
         inherits.push(member.inherit)
@@ -1232,7 +1232,7 @@ loop do
   def newgroup
     ln = []
     lnindex = 0
-    for lk in Lists.langs.keys
+    Lists.langs.keys.each do |lk|
       l = Lists.langs[lk]
       ln.push(l["name"] + " (" + l["nativeName"] + ")")
       lnindex = ln.size - 1 if Configuration.language.downcase[0..1] == lk.downcase[0..1]
@@ -1338,11 +1338,11 @@ chk_transcriptions.checked=false if !requires_premiumpackage("courier")
   def forumsload(group)
         @sforums = []
     if group >= 0
-      for f in @forums
+      @forums.each do |f|
         @sforums.push(f) if f.group.id == group
       end
     elsif group == -5
-      for f in @forums
+      @forums.each do |f|
         @sforums.push(f) if f.followed
       end
     end
@@ -1350,7 +1350,7 @@ chk_transcriptions.checked=false if !requires_premiumpackage("courier")
       forum_order = {}
       @sforums.each_with_index { |forum, i| forum_order[forum.name] = i }
       forum_last_update = Hash.new(0)
-      for thread in @threads
+      @threads.each do |thread|
         forum = thread.forum
         next if forum == nil || !forum_order.key?(forum.name)
         forum_last_update[forum.name] = thread.lastupdate if forum_last_update[forum.name] < thread.lastupdate
@@ -1364,10 +1364,10 @@ chk_transcriptions.checked=false if !requires_premiumpackage("courier")
       @sforums.sort! {|a,b| forumsorter(a,b)}
     end
     frmselt = []
-    for forum in @sforums
+    @sforums.each do |forum|
       name_parts = [forum.fullname]
       if group == -5
-        for g in @groups
+        @groups.each do |g|
           name_parts << " (#{g.name}) " if g.id == forum.group.id
         end
       end
@@ -1406,7 +1406,7 @@ def forumtagsedit(forum)
   return if forum.group.role!=2
   tags = forumtags(forum)
   selt=[]
-  for t in tags
+  tags.each do |t|
     selt.push(t[1]+": "+t[2..-1].join(", "))
   end
   sel=ListBox.new(selt, header: p_("Forum", "Forum tags"), index: 0, flags: 0, quiet: false)
@@ -1558,7 +1558,7 @@ form.focus
           if forum_attempt(nil) {
             EltenLink::Forum.mark_forum_as_read(elten_link, forum: @sforums[@frmsel.index].name)
           }
-            for t in @threads
+            @threads.each do |t|
               t.readposts = t.posts if t.forum.name == @sforums[@frmsel.index].name
             end
             @sforums[@frmsel.index].readposts = @sforums[@frmsel.index].posts
@@ -1718,7 +1718,7 @@ break
     index = @lastthreadindex
     @lastthreadindex = nil
     @forumtype = 0
-    for forum in @forums
+    @forums.each do |forum|
       @forumtype = forum.type if forum.name == id
     end
     @sthreads = []
@@ -1735,7 +1735,7 @@ break
     rsl=[]
     if id==-3
       rsl=[]
-      for r in @results
+      @results.each do |r|
         i=r/100
         rsl[i]=[] if rsl[i]==nil
         rsl[i].push(r)
@@ -1753,7 +1753,7 @@ break
           end
       when -11
               r=[]
-        for mention in @mentions
+        @mentions.each do |mention|
           if t.id == mention.thread
             th=t.clone
             th.mention = mention
@@ -1781,7 +1781,7 @@ break
           end
       when -7
         r=[]
-        for mention in @mentions
+        @mentions.each do |mention|
           if t.id == mention.thread
             th=t.clone
             th.mention = mention
@@ -1791,7 +1791,7 @@ break
         r
       when -6
         folfor = []
-        for forum in @forums
+        @forums.each do |forum|
           folfor.push(forum.name) if forum.followed == true
         end
         if folfor.include?(t.forum.name) and t.readposts < t.posts
@@ -1801,7 +1801,7 @@ break
           end
       when -4
         folfor = []
-        for forum in @forums
+        @forums.each do |forum|
           folfor.push(forum.name) if forum.followed == true
         end
         if folfor.include?(t.forum.name) and t.readposts == 0
@@ -1954,7 +1954,7 @@ threadopen(@thrsel.index)
   
   def context_threads(menu)
     group = Struct_Forum_Group.new
-    for f in @forums
+    @forums.each do |f|
       group = f.group if f.name == @forum
     end
     if @sthreads.size > 0
@@ -2035,10 +2035,10 @@ threadopen(@thrsel.index)
           selt = []
           ind = 0
           mforums = []
-          for f in @forums
+          @forums.each do |f|
             mforums.push(f) if f.group.role == 2 or (Session.moderator == 1 && f.group.recommended)
           end
-          for f in mforums
+          mforums.each do |f|
             selt.push(f.fullname + " (" + f.group.name + ")")
             ind = selt.size-1 if f.name == @sthreads[@thrsel.index].forum.name
           end
@@ -2122,7 +2122,7 @@ threadopen(@thrsel.index)
         users=[]
 forum_fetch([], nil) { EltenLink::Forum.group_members(elten_link, group_id: @sthreads[@thrsel.index].forum.group.id) }.each { |member| users.push(member.user) }
         dgroups=[]
-        for g in @groups
+        @groups.each do |g|
           dgroups.push(g) if g.role>0 and users.include?(g.founder) and g.id!=@sthreads[@thrsel.index].forum.group.id
           end
         dests=dgroups.map{|g|g.name+" - "+p_("Forum", "Group founded by %{founder}")%{:founder=>g.founder}}
@@ -2157,7 +2157,7 @@ forum_fetch([], nil) { EltenLink::Forum.group_members(elten_link, group_id: @sth
       if @sthreads[@thrsel.index].offered>0
         gr=nil
         suc=false
-        for g in @groups
+        @groups.each do |g|
           if g.id==@sthreads[@thrsel.index].offered and g.role==2
           suc=true
           gr=g
@@ -2167,7 +2167,7 @@ forum_fetch([], nil) { EltenLink::Forum.group_members(elten_link, group_id: @sth
           menu.submenu(p_("Forum", "Thread transfer offer to group %{groupname}")%{:groupname=>gr.name}) {|m|
           m.option(p_("Forum", "Accept this offer"), nil, "A") {
             forums=[]
-            for f in @forums
+            @forums.each do |f|
               forums.push(f) if f.group.id==gr.id
             end
             if forums.size>0
@@ -2292,17 +2292,17 @@ when :move
           selt = []
           ind = 0
           mforums = []
-          for f in @forums
+          @forums.each do |f|
             mforums.push(f) if f.group.role == 2 or (Session.moderator == 1 && f.group.recommended)
           end
-          for f in mforums
+          mforums.each do |f|
             selt.push(f.fullname + " (" + f.group.name + ")")
             ind = selt.size-1 if f.name == threads[0].forum.name
           end
           destination = selector(selt, header: p_("Forum", "Threads destination"), start_index: ind, cancel_index: -1)
           if destination != -1
             if forum_attempt(nil) {
-              for thread in threads
+              threads.each do |thread|
                 EltenLink::Forum.move_thread(elten_link, thread_id: thread.id, forum: mforums[destination].name)
               end
             }
@@ -2315,7 +2315,7 @@ when :move
               end
             when :delete
               if forum_attempt(nil) {
-                for thread in threads
+                threads.each do |thread|
                   EltenLink::Forum.delete_thread(elten_link, thread_id: thread.id)
                 end
               }
@@ -2327,7 +2327,7 @@ when :offer
           users=[]
 forum_fetch([], nil) { EltenLink::Forum.group_members(elten_link, group_id: @sthreads[@thrsel.index].forum.group.id) }.each { |member| users.push(member.user) }
         dgroups=[]
-        for g in @groups
+        @groups.each do |g|
           dgroups.push(g) if g.role>0 and users.include?(g.founder) and g.id!=@sthreads[@thrsel.index].forum.group.id
           end
         dests=dgroups.map{|g|g.name+" - "+p_("Forum", "Group founded by %{founder}")%{:founder=>g.founder}}
@@ -2335,7 +2335,7 @@ forum_fetch([], nil) { EltenLink::Forum.group_members(elten_link, group_id: @sth
         if ind>=0
         dest=dgroups[ind]
         if forum_attempt(nil) {
-          for thread in threads
+          threads.each do |thread|
             next if thread.offered!=0
             EltenLink::Forum.offer_thread(elten_link, thread_id: thread.id, group_id: dest.id)
           end
@@ -2365,8 +2365,8 @@ form.wait
     forums = []
     forumclasses = []
     forumindex = 0
-    for g in @groups
-      for f in @forums
+    @groups.each do |g|
+      @forums.each do |f|
         if f.type == @forumtype && !f.closed
           if f.group.id == g.id
             forums.push(f.fullname + " (#{g.name})")
@@ -2391,7 +2391,7 @@ form.wait
     tin=false
     tin=true if form.index==form.fields.size-3
     f=[]
-    for t in forumtags(forumclasses[form.fields[-3].index])
+    forumtags(forumclasses[form.fields[-3].index]).each do |t|
       f.push(ListBox.new([p_("Forum", "No tag value")]+t[2..-1], header: t[1], index: 0))
     end
     if type==1
@@ -2528,7 +2528,7 @@ form.wait
     end
     return if ![1,2].include?(forumclasses[form.fields[-3].index].group.role) and !canjoin(forumclasses[form.fields[-3].index].group)
     name=""
-    for f in form.fields[7...-4]
+    form.fields[7...-4].each do |f|
       if f.index>0
         name+="["+f.options[f.index]+"] "
         end
@@ -2541,7 +2541,7 @@ form.wait
       attachments = nil
       if files.size > 0
         atts = ""
-        for f in files
+        files.each do |f|
           atts += send_attachment(f) + ","
         end
         atts.chop! if atts[-1..-1] == ","
@@ -2620,7 +2620,7 @@ if flp[0..3] != "OggS"
         @results = []
     if @query != "" and @query.is_a?(String)
       sr = forum_fetch([], nil) { EltenLink::Forum.search(elten_link, query: @query) }
-        for result in sr
+        sr.each do |result|
             thread = @threads.find{|t|t.id==result.thread}
             @results.push(thread.id) if thread!=nil
         end
@@ -2820,7 +2820,7 @@ loop do
     end
     @fields = []
     return if @posts == nil
-    for i in 0...@posts.size
+    (0...@posts.size).each do |i|
       post = @posts[i]
       index = i * 3 if index == -1 and @param == -3 and @query.is_a?(Struct_Forum_SearchQuery) and post.post.downcase.include?(@query.phrase.downcase) && @query.phrase_in.include?(:content)
       index = i * 3 if index == -1 and @param == -3 and @query.is_a?(Struct_Forum_SearchQuery) and post.transcription.downcase.include?(@query.phrase.downcase) && @query.phrase_in.include?(:content) && @query.transcriptions
@@ -2842,7 +2842,7 @@ end
       @fields[-1] = ListBox.new(name_attachments(post.attachments), header: p_("Forum", "Attachments")) if post.attachments.size > 0
       if post.polls.size > 0
         names = []
-        for o in post.polls
+        post.polls.each do |o|
           begin
             poll = EltenLink::Polls.get(elten_link, o)
             names.push(poll.name)
@@ -2934,7 +2934,7 @@ end
       attachments = nil
       if @attachments.size > 0
         atts = ""
-        for f in @attachments
+        @attachments.each do |f|
           atts += send_attachment(f) + ","
         end
         atts.chop! if atts[-1..-1] == ","
@@ -3074,7 +3074,7 @@ if post.edited && !post.locked
     }
       m.option(p_("Forum", "Go to post"), nil, "j") {
         selt = []
-        for i in 0..@posts.size - 1
+        (0..@posts.size - 1).each do |i|
           selt.push((i + 1).to_s + " / " + @postscount.to_s + ": " + @posts[i].author)
         end
                 @form.index = selector(selt, header: p_("Forum", "Select post"), start_index: @form.index / 3, cancel_index: @form.index / 3) * 3
@@ -3094,7 +3094,7 @@ if post.edited && !post.locked
             selt = []
             sr = []
             ind = -1
-            for i in 0..@posts.size - 1
+            (0..@posts.size - 1).each do |i|
               if @posts[i].post.downcase.include?(search.downcase)
                 selt.push((i + 1).to_s + ": " + @posts[i].author)
                 sr.push(i)
@@ -3137,7 +3137,7 @@ if post.edited && !post.locked
       menu.option(p_("Forum", "Listen to the thread")) {
         if speech_output_nvda? and @type == 0
           text = ""
-          for pst in @posts[@form.index / 3..@posts.size]
+          @posts[@form.index / 3..@posts.size].each do |pst|
             text += pst.author + "\r\n" + pst.post + "\r\n" + pst.date + "\r\n\r\n"
           end
           speak(text)
@@ -3240,7 +3240,7 @@ end
             @forums = @struct["forums"]
             @threads = @struct["threads"]
             groups = []
-            for group in @groups
+            @groups.each do |group|
               groups[group.id] = group.name
             end
             forums = {}
@@ -3248,7 +3248,7 @@ end
             fthreads = []
             hthreads=[]
             curr = 0
-            for t in @threads
+            @threads.each do |t|
               if t.forum.group.role == 2 or (Session.moderator == 1 and t.forum.group.recommended)
                 if t.forum.group.id==@threadclass.forum.group.id
               hthreads.push(t)
@@ -3258,7 +3258,7 @@ end
               end
             end
             mthreads=hthreads+fthreads
-            for t in mthreads
+            mthreads.each do |t|
               selt.push(t.name + " (" + t.forum.fullname + " (" + t.forum.group.name + ")" + ")")
               curr = selt.size - 1 if t.id == @thread
             end
@@ -3313,7 +3313,7 @@ end
           }
           m.option(p_("Forum", "Change post position")) {
             sels = []
-            for post in @posts
+            @posts.each do |post|
               sels.push((sels.size + 1).to_s + ": " + post.author + ": " + post.date)
             end
             sels.push(p_("Forum", "Move to end"))
@@ -3412,7 +3412,7 @@ when :move
             @forums = @struct["forums"]
             @threads = @struct["threads"]
             groups = []
-            for group in @groups
+            @groups.each do |group|
               groups[group.id] = group.name
             end
             forums = {}
@@ -3420,7 +3420,7 @@ when :move
             fthreads = []
             hthreads=[]
             curr = 0
-            for t in @threads
+            @threads.each do |t|
               if t.forum.group.role == 2 or (Session.moderator == 1 and t.forum.group.recommended)
                 if t.forum.group.id==@threadclass.forum.group.id
               hthreads.push(t)
@@ -3430,14 +3430,14 @@ when :move
               end
             end
             mthreads=hthreads+fthreads
-            for t in mthreads
+            mthreads.each do |t|
               selt.push(t.name + " (" + t.forum.fullname + " (" + t.forum.group.name + ")" + ")")
               curr = selt.size - 1 if t.id == @thread
             end
             destination = selector(selt, header: p_("Forum", "Post destination"), start_index: curr, cancel_index: -1)
             if destination != -1
               if forum_attempt(nil) {
-                for post in posts
+                posts.each do |post|
                   EltenLink::Forum.move_post(elten_link, post_id: post.id, thread_id: mthreads[destination].id)
                 end
               }
@@ -3448,7 +3448,7 @@ when :move
             end
   when :delete
     if forum_attempt(nil) {
-      for post in posts
+      posts.each do |post|
         EltenLink::Forum.delete_post(elten_link, post_id: post.id)
       end
     }
@@ -3494,7 +3494,7 @@ btn_mentionOK.on(:press) {
 if lst_users.multiselections.size >= 0
 selections = lst_users.multiselections()
 sent = forum_attempt(nil) {
-  for i in 0..selections.size - 1
+  (0..selections.size - 1).each do |i|
     EltenLink::Forum.create_mention(elten_link, user: users[selections[i]], message: edt_message.text, thread_id: thread, post_id: post)
   end
 }
@@ -3535,7 +3535,7 @@ form.wait
     dialog_open
     attnames = name_attachments(post.attachments)
     atts=[]
-    for i in 0...post.attachments.size
+    (0...post.attachments.size).each do |i|
       a=post.attachments[i]
       atts.push([a, nil, attnames[i]])
       end
@@ -3574,7 +3574,7 @@ form.wait
               form.update
               if form.fields[0].text.size > 0 and (((key_pressed?(:key_enter) or key_pressed?(:key_space)) and form.index == 3) or (key_pressed?(:key_enter) and key_held?(0x11) and form.index < 3))
                 attachments=""
-        for a in atts
+        atts.each do |a|
           if a[0]==nil
           attachments += send_attachment(a[1]) + ","
         else
@@ -3599,8 +3599,8 @@ form.wait
   def showbookmarks
     loop_update
     bookmarks=forum_fetch([], nil) { EltenLink::Forum.list_bookmarks(elten_link, thread_id: @thread) }
-    for b in bookmarks
-      for i in 0...@posts.size
+    bookmarks.each do |b|
+      (0...@posts.size).each do |i|
         b.postnum=i if @posts[i].id==b.post
       end
     end
@@ -3922,7 +3922,7 @@ def make_setting(label, type, key, mapping=nil)
   @settings.last.push([label, type, key, mapping])
 end
 def save_category
-  for i in 2...@settings[@category].size
+  (2...@settings[@category].size).each do |i|
     setting=@settings[@category][i]
     next if setting==nil || setting[1]==:custom
     index=i-1
@@ -3942,7 +3942,7 @@ def show_category(id)
   @form.show_all
   @form.fields[1...-3]=[]
   f=[]
-for s in @settings[id][2..-1]
+@settings[id][2..-1].each do |s|
   label, type, key, mapping = s
   field=nil
   case type
@@ -3970,7 +3970,7 @@ end
 def apply_settings
   save_category
   j={}
-  for k in @values.keys
+  @values.keys.each do |k|
     v=@values[k]
     j[k]=v
   end
@@ -3990,7 +3990,7 @@ def load_general
   langs=[]
   langsmapping=[]
   getconfig if @languages==nil
-  for lang in Lists.langs.keys
+  Lists.langs.keys.each do |lang|
     l=Lists.langs[lang]
     langsmapping.push(lang)
     langs.push(l['name']+"("+l['nativeName']+")")
@@ -4018,7 +4018,7 @@ if holds_premiumpackage("scribe")
 blogids=[]
 blognames=[]
 b=EltenLink::Blog.managed(elten_link)
-for blog in b
+b.each do |blog|
 blogids.push(blog.id.to_s)
 blognames.push(blog.name.to_s)
 end

--- a/src/scenes/honors.rb
+++ b/src/scenes/honors.rb
@@ -20,7 +20,7 @@ class Scene_Honors
     end
     selt=[]
     ind=0
-    for h in @honors
+    @honors.each do |h|
       ind=selt.size if h.id==@honor
       selt.push(makeselt(h))
     end
@@ -79,7 +79,7 @@ else
                   selt+=h.enlevels[0]
                 end
               elsif h.levels.size>1
-                for i in h.level...h.levels.size
+                h.level...h.levels.size.each do |i|
                   selt+=p_("Honors", "Level")+(i+1).to_s+": "
                   if Configuration.language=="pl-PL"
                     selt+=h.levels[i]
@@ -143,7 +143,7 @@ if Session.moderator==1
     levels=honor.levels.deep_dup
     enlevels=honor.enlevels.deep_dup
     selt=[]
-    for i in 0..levels.size-1
+    (0..levels.size-1).each do |i|
       selt.push("#{i+1}: #{levels[i]}, #{enlevels[i]}")
       end
     selt+=[p_("Honors", "Add challenge")]
@@ -156,7 +156,7 @@ if Session.moderator==1
         levels.delete_at(form.fields[0].index)
         enlevels.delete_at(form.fields[0].index)
         selt=[]
-    for i in 0..levels.size-1
+    (0..levels.size-1).each do |i|
       selt.push("#{i+1}: #{levels[i]}, #{enlevels[i]}")
       end
     selt+=[p_("Honors", "Add challenge")]
@@ -194,7 +194,7 @@ loop do
     end
   end
   selt=[]
-    for i in 0..levels.size-1
+    (0..levels.size-1).each do |i|
       selt.push("#{i+1}: #{levels[i]}, #{enlevels[i]}")
       end
     selt+=[p_("Honors", "Add challenge")]
@@ -241,7 +241,7 @@ loop do
     end
     }
                 selt = []
-    for i in 0...@selt.size
+    (0...@selt.size).each do |i|
       u=@selt[i]
       selt.push(user_with_status(u, false))
       end

--- a/src/scenes/loading.rb
+++ b/src/scenes/loading.rb
@@ -82,8 +82,8 @@ v={
 'SoundTheme' => [['Path','Interface','SoundTheme']]
 }
 begin
-for k in v.keys
-  for o in v[k]
+v.keys.each do |k|
+  v[k].each do |o|
     o[1]=k if o[1]==nil
     o[2]=o[0] if o[2]==nil
         val=readini(EltenPath.join(Dirs.eltendata, "config", (k+"")+".ini"), k+"", o[0], "")
@@ -101,7 +101,7 @@ begin
 FileUtils.rm_rf(EltenPath.join(Dirs.eltendata, "lng"))
 if FileTest.exists?(EltenPath.join(Dirs.soundthemes, "inis"))
 d=Dir.entries(EltenPath.join(Dirs.soundthemes, "inis"))
-for f in d
+d.each do |f|
   next if !f.include?(".ini")
   name=readini(EltenPath.join(Dirs.soundthemes, "inis", f), "SoundTheme", "Name", "")
   path=readini(EltenPath.join(Dirs.soundthemes, "inis", f), "SoundTheme", "Path", "")
@@ -199,7 +199,7 @@ if oldfiles.size > 0
 loop {
 suc=true
 dr=Dir.entries("bin")
-for d in dr
+dr.each do |d|
   suc=false if oldfiles.include?(d.downcase)
 end
 break if suc

--- a/src/scenes/main.rb
+++ b/src/scenes/main.rb
@@ -413,11 +413,11 @@ def acsel_load(fc=true)
       @acsel.index=[options.size-1, 0].max
     end
     @acsel.index=0 if @acsel.index<0
-    for i in 0...@actions.size
+    (0...@actions.size).each do |i|
       @acsel.enable_item(@specials.size+i)
       end
   end
-      for i in 0...@actions.size
+      (0...@actions.size).each do |i|
       @acsel.disable_item(@specials.size+i) if @actions[i].show==false && !@acselshowhidden
     end
         @acsel.focus if fc==true
@@ -435,7 +435,7 @@ def accontext(menu)
   menu.option(p_("Main", "Change hotkey"), nil, "k") {
   s=[p_("Main", "None")]
   k=[0]
-  for i in 1..11
+  (1..11).each do |i|
     s.push("F"+i.to_s)
     k.push(i)
     s.push("SHIFT+F"+i.to_s)
@@ -520,12 +520,12 @@ def action_add
   actions=[]
   actionlabels=[]
     c=QuickActions.predefined_procs
-  for a in c
+  c.each do |a|
     actions.push(a[0])
     actionlabels.push(a[1])
   end
     g=GlobalMenu.scenes
-  for m in g
+  g.each do |m|
     actions.push(m[1])
     actionlabels.push(m[0])
   end
@@ -547,7 +547,7 @@ def feeds_load(fc=false)
   @@feed_id = @feeds[@feedsel.index].id if @feeds.is_a?(Array) && @feeds.size>0 && @feedsel!=nil
   @feeds=[]
   ind=-1
-  for f in Session.feeds.keys.sort.reverse
+  Session.feeds.keys.sort.reverse.each do |f|
     feed=Session.feeds[f]
     @feeds.push(feed) if feed!=nil && feed.message!=""
     ind=@feeds.size-1 if ind==-1 && @@feed_id>0 && feed.id<=@@feed_id
@@ -627,10 +627,10 @@ dialog_close
     users=[feed.user]
     users+=feed.message.scan(/\@([a-zA-Z0-9\.\-\_]+)/).map{|r|r[0]}
     todel=[]
-    for u in users
+    users.each do |u|
       todel.push(u) if u.downcase==Session.name.downcase
     end
-    for i in 1...users.size
+    (1...users.size).each do |i|
       todel.push(users[i]) if users[0...i].map{|u|u.downcase}.include?(users[i].downcase)
       end
     todel.each{|u|users.delete(u)}
@@ -670,7 +670,7 @@ def feed_new(users=[], response=0)
   feed(inp, response) if inp!=nil
 end
 def feed_id=(f)
-  for i in 0...@feeds.size
+  (0...@feeds.size).each do |i|
     @feedsel.index=i if @feeds[i].id>=f
     end
   end

--- a/src/scenes/messages.rb
+++ b/src/scenes/messages.rb
@@ -127,7 +127,7 @@ def import(arr)
     selt=[]
     states=[]
     ind=0
-    for u in @users
+    @users.each do |u|
       user=utf8(u.name)
       user=u.user if u.name=="" || u.name==nil
                   selt.push(user+":\r\n"+p_("Messages", "Last message")+": "+utf8(u.lastuser)+": "+utf8(u.lastsubject)+".\r\n"+format_date(u.lastdate)+"\r\n")
@@ -211,7 +211,7 @@ end
 if @users[@sel_users.index].muted==false
   menu.submenu(p_("Messages", "Mute this conversation")) {|m|
   ms=[[p_("Messages", "Mute for a quarter"), 900], [p_("Messages", "Mute for an hour"), 3600], [p_("Messages", "Mute for a day"), 86400], [p_("Messages", "Mute for a week"), 86400*7], [p_("Messages", "Mute until manually unmuted"), 0]]
-  for mt in ms
+  ms.each do |mt|
     m.option(mt[0], mt[1]) {|t|
     mute_conversation(@users[@sel_users.index], t)
     }
@@ -343,7 +343,7 @@ def edit_conversation(c=nil)
 if form.fields[2]!=nil and form.fields[2].pressed?
   addusers=[]
   if c!=nil
-    for u in users
+    users.each do |u|
       addusers.push(u) if !cusers.include?(u)
       end
   end
@@ -432,7 +432,7 @@ if result.conversations.empty? and sp=='new'
         selt=[]
         states=[]
         ind=0
-    for c in @conversations
+    @conversations.each do |c|
       lu=utf8(c.lastuser)
       lu=@conversation_name if @conversation_name!="" && @conversation_name!=nil && lu[0..0]=="["
       lu=name_conversation(lu) if lu[0..0]=="["
@@ -557,7 +557,7 @@ end
          selt=[]
          states=[]
          audio_urls=[]
-    for m in @messages
+    @messages.each do |m|
       if !curids.include?(m.id)
       if complete
       play_sound("messages_update")

--- a/src/scenes/notes.rb
+++ b/src/scenes/notes.rb
@@ -20,7 +20,7 @@ class Scene_Notes
     return
     end
   selt=[]
-  for n in @notes
+  @notes.each do |n|
     selt.push(n.name+"\r\n#{p_("Notes", "Author")}: "+n.author+"\r\n#{p_("Notes", "Modified")}: "+format_date(n.modified, false, false))
   end
   @sel=ListBox.new(selt,header: p_("Notes", "Notes"), index: index, flags: 0, quiet: false)

--- a/src/scenes/online.rb
+++ b/src/scenes/online.rb
@@ -14,7 +14,7 @@ class Scene_Online
       alert(_("Error"))
     end
                 selt = []
-    for u in @onl
+    @onl.each do |u|
       selt.push(user_with_status(u, false))
     end
     cnt=@onl.size

--- a/src/scenes/piano.rb
+++ b/src/scenes/piano.rb
@@ -50,7 +50,7 @@ freqs = {
 0xBE=>622.3,
 0xBF=>740.0
 }
-for k,freq in freqs
+freqs.each do |k,freq|
   if key_pressed?(k)
 if freq != 0
 a=Sound.new(stream: getsound("signal", true))

--- a/src/scenes/polls.rb
+++ b/src/scenes/polls.rb
@@ -64,12 +64,12 @@ def polls_filter
   @lastpoll=@polls[@sel.index].id if @polls.is_a?(Array) and @polls.size>0
   @polls=[]
 knownlanguages = Session.languages.split(",").map{|lg|lg.upcase}
-for pl in @allpolls
+@allpolls.each do |pl|
   @polls.push(pl) if LocalConfig["PollsShowUnknownLanguages"]==1 || knownlanguages.size==0 || knownlanguages.include?(pl.language[0..1].upcase)
   end
 selt=[]
 index=0
-for poll in @polls
+@polls.each do |poll|
 if poll != nil
   selt.push([poll.name, poll.author, poll.votes.to_s, poll.description])
     index=selt.size-1 if poll.id==@lastpoll
@@ -139,7 +139,7 @@ class Scene_Polls_Create
       @ln = []
       ls=[]
     lnindex = 0
-    for lk in Lists.langs.keys
+    Lists.langs.keys.each do |lk|
       l = Lists.langs[lk]
       ls.push(l["name"] + " (" + l["nativeName"] + ")")
       @ln.push(lk)
@@ -260,7 +260,7 @@ else
   end
   end
 qu=[]
-           for q in @questions
+           @questions.each do |q|
   qu.push(q[0]) if q!=nil
   end
   @fields[3].options = qu
@@ -347,7 +347,7 @@ end
 @description=poll.description
     txt="#{@name}\r\n#{p_("Polls", "Author")}: #{@author}\r\n#{p_("Polls", "Created")}: #{format_date(@created)}\r\n\r\n#{@description}"
     qs=[]
-for q in @questions
+@questions.each do |q|
   if q[1]==2
     qs.push(EditBox.new(q[0],text: "",quiet: true))
     qs.last.on(:change) {@changed=true}
@@ -393,19 +393,19 @@ loop do
 if key_pressed?(:key_enter) or key_pressed?(:key_space)
   if @form.index==@form.fields.size-2
     ans=""
-    for i in 1..@questions.size
+    (1..@questions.size).each do |i|
 case @questions[i-1][1]
 when 0
   ans+=(i-1).to_s+":"+@form.fields[i].index.to_s+"\r\n"
   when 1
-for j in 0..@form.fields[i].options.size-1
+(0..@form.fields[i].options.size-1).each do |j|
     ans+=(i-1).to_s+":"+j.to_s+"\r\n" if @form.fields[i].selected[j]==true
   end
   when 2
     ans+=(i-1).to_s+":"+@form.fields[i].text.gsub(";"," ").gsub(":"," ").delete("\r\n")+"\r\n" if @form.fields[i].text!=""
   else
     if @questions[i-1][1]<0
-    for j in 0..@form.fields[i].options.size-1
+    (0..@form.fields[i].options.size-1).each do |j|
     ans+=(i-1).to_s+":"+j.to_s+"\r\n" if @form.fields[i].selected[j]==true
   end
   end
@@ -482,17 +482,17 @@ results.answers.each do |answer|
   b=[r,a]
     @answers[q].push(b)
 end
-for q in 0..@questions.size-1
+(0..@questions.size-1).each do |q|
   if @answers[q]!=nil
   txt+=@questions[q][0].to_s+"\r\n"
 if @questions[q][1]<2
-   for i in 2...@questions[q].size
+   (2...@questions[q].size).each do |i|
    a=i-2
 pr=(@answers[q].map{|x|x[1]}.count(a).to_f/@votes.to_f*100.0).to_i
 txt+=@questions[q][i]+": "+pr.to_s+"%\r\n"
    end
 else
-  for a in @answers[q]
+  @answers[q].each do |a|
     txt+=": "+a[1]+"\r\n"
     end
 end  
@@ -529,7 +529,7 @@ end
 @poll.created = poll.created
 @questions=[]
 qs=poll.questions
-for qu in qs
+qs.each do |qu|
   q=Struct_Polls_Question.new
   q.question=qu[0]
   q.type=qu[1].to_i
@@ -582,7 +582,7 @@ end
 def answers_context(menu)
   return if @sel_answers.rows.size==0
   suc=false
-  for f in @filters
+  @filters.each do |f|
     suc=true if f==@sel_questions.index && f==@curanswers[@sel_answers.index]
     end
 if suc==false
@@ -596,7 +596,7 @@ if suc==false
   }
 else
   menu.option(p_("Polls", "Delete this answer from filters")) {
-  for f in @filters
+  @filters.each do |f|
     @filters.delete(f) if f[0]==@sel_questions.index and f[1]==@curanswers[@sel_answers.index]
   end
   update_filters
@@ -614,17 +614,17 @@ def filters_context(menu)
   end
 def update_answers
   authors=@answers.map{|a|a.author}.uniq
-  for f in @filters
-    for author in authors.deep_dup
+  @filters.each do |f|
+    authors.deep_dup.each do |author|
 if f[2]==true
   suc=false
-  for a in @answers
+  @answers.each do |a|
     suc=true if a.author==author && a.question==f[0] && a.answer==f[1]
   end
   authors.delete(author) if suc==false
 else
   suc=true
-  for a in @answers
+  @answers.each do |a|
     suc=false if a.author==author && a.question==f[0] && a.answer==f[1]
   end
   authors.delete(author) if suc==false
@@ -637,13 +637,13 @@ end
   if q.type<2
     anses=[]
           answersList = []
-    for a in @answers
+    @answers.each do |a|
       next if !authors.include?(a.author)
       if a.question==@sel_questions.index
         anses.push(a.answer)
       end
     end
-    for a in 0...q.answers.size
+    (0...q.answers.size).each do |a|
       if anses.size>0
       prc=(anses.count(a).to_f/authors.size.to_f*100.0).floor
     else
@@ -657,7 +657,7 @@ end
         @curanswers.push(a[2])
       end
   else
-    for a in @answers
+    @answers.each do |a|
       next if !authors.include?(a.author)
       if a.question==@sel_questions.index
         @sel_answers.rows.push([a.answer.to_s]) if a.answer.to_s!=""
@@ -670,7 +670,7 @@ end
   end
   def update_filters
     @sel_filters.options=[]
-    for f in @filters
+    @filters.each do |f|
       q=@questions[f[0]]
       ans=f[1]
       ans=q.answers[f[1]] if q.type<2

--- a/src/scenes/premiumpackages.rb
+++ b/src/scenes/premiumpackages.rb
@@ -193,7 +193,7 @@ sactivate=p_("PremiumPackages", "Activate package using code")
     begin
       active_until=EltenLink::PremiumPackages.active_until(elten_link)
       active_until.each do |package, totime|
-        for c in @packages
+        @packages.each do |c|
           c.totime=totime if c.package==package
           end
         end
@@ -201,8 +201,8 @@ sactivate=p_("PremiumPackages", "Activate package using code")
     end
       begin
         j=EltenLink::Payments.prices(elten_link)
-        for k in j.keys
-          for c in @packages
+        j.keys.each do |k|
+          @packages.each do |c|
             if c.package==k
               c.activable=true  
               c.price=j[k]["price$#{@currency}"]
@@ -222,7 +222,7 @@ sactivate=p_("PremiumPackages", "Activate package using code")
         conversionprice=nil
                 if c.package=="sponsor"
           z=0
-          for g in @packages.find_all{|pc|pc.package!="sponsor"}
+          @packages.find_all{|pc|pc.package!="sponsor"}.each do |g|
             d=((g.totime-Time.now.to_f)/86400).floor
             d=0 if d<0
             z+=(g.price*0.9)/365.0*d
@@ -231,7 +231,7 @@ sactivate=p_("PremiumPackages", "Activate package using code")
         end
 if c.package=="orchestra"
           z=0
-          for g in @packages.find_all{|pc|pc.package!="orchestra"}
+          @packages.find_all{|pc|pc.package!="orchestra"}.each do |g|
             d=((g.totime-Time.now.to_f)/86400).floor
             d=0 if d<0
             z+=(g.price*0.9)/365.0*d
@@ -276,7 +276,7 @@ The granting of a premium package does not constitute a commitment or a commerci
      methods=[]
      begin
        j=EltenLink::Payments.methods(elten_link, currency: @currency, language: Configuration.language)
-       for m in j
+       j.each do |m|
          if m['id']=='transfer' and m['type']=='transfer'
            transfer=m
          end
@@ -348,7 +348,7 @@ form=Form.new([
       if package!=nil and package.package=="sponsor" and convert==true
         conversionprice=package.price
           z=0
-          for g in @packages.find_all{|c|c.package!="sponsor"}
+          @packages.find_all{|c|c.package!="sponsor"}.each do |g|
             d=((g.totime-Time.now.to_f)/86400).floor
             d=0 if d<0
             z+=(g.price*0.9)/365.0*d
@@ -385,7 +385,7 @@ form=Form.new([
       if package!=nil and package.package=="sponsor" and convert==true
         conversionprice=package.price
           z=0
-          for g in @packages.find_all{|c|c.package!="sponsor"}
+          @packages.find_all{|c|c.package!="sponsor"}.each do |g|
             d=((g.totime-Time.now.to_f)/86400).floor
             d=0 if d<0
             z+=(g.price*0.9)/365.0*d

--- a/src/scenes/settings.rb
+++ b/src/scenes/settings.rb
@@ -38,7 +38,7 @@ def make_setting(label, type, section, config=nil, mapping=nil, multi=false)
   @settings.last.push([label, type, section, config, mapping, multi])
 end
 def save_category
-  for i in 2...@settings[@category].size
+  (2...@settings[@category].size).each do |i|
     setting=@settings[@category][i]
         next if setting==nil || setting[1]==:custom
     index=i-1
@@ -52,7 +52,7 @@ def save_category
       mpg=setting[4]
       mpg=(0...setting[1].size).to_a.map{|a|a.to_s} if mpg==nil
       vl=[]
-      for i in 0...mpg.size
+      (0...mpg.size).each do |i|
         vl.push(mpg[i]) if field.selected[i]
       end
       val=vl.join(",")
@@ -67,7 +67,7 @@ def show_category(id)
   @form.show_all
   @form.fields[1...-3]=[]
   f=[]
-for s in @settings[id][2..-1]
+@settings[id][2..-1].each do |s|
   label, type, section, config, mapping, multi = s
   field=nil
   case type
@@ -95,7 +95,7 @@ for s in @settings[id][2..-1]
       mpg||=(0...type.size).to_a.map{|a|a.to_s}
       mpg=mpg.map{|a|a.delete(",")}
       flds=currentconfig(section, config).split(",")
-      for f in flds
+      flds.each do |f|
         ind=mpg.find_index(f)
         field.selected[ind]=true if ind!=nil
         end
@@ -107,7 +107,7 @@ end
 end
 def apply_settings
   save_category
-  for k in @values.keys
+  @values.keys.each do |k|
     v=@values[k]
     writeconfig(k[0], k[1], v)
   end
@@ -124,7 +124,7 @@ def make_window
     setting_category(p_("Settings", "General"))
         l=loadedlanguages.map{|l|l.realcode}
         langsmapping=["en-GB"]
-    for d in l
+    l.each do |d|
         langsmapping.push(d) if !langsmapping.include?(d)
         end
   langsmapping=langsmapping.find_all{|l|Lists.langs[l[0..1].downcase].is_a?(Hash)}
@@ -177,7 +177,7 @@ def make_window
         make_setting(p_("Settings", "Speech rate"), (0..100).to_a.reverse.map{|x|x.to_s+"%"}, "Voice", "Rate", (0..100).to_a.reverse)
         make_setting(p_("Settings", "Speech volume"), (5..100).to_a.reverse.map{|x|x.to_s+"%"}, "Voice", "Volume", (5..100).to_a.reverse)
         make_setting(p_("Settings", "Speech pitch"), (0..100).to_a.reverse.map{|x|x.to_s+"%"}, "Voice", "Pitch", (0..100).to_a.reverse)
-        make_setting(p_("Settings", "Enable braille output (requires NVDA addon)"), :bool, "Interface", "EnableBraille") if SpeechOutput.list.any?{|output| output.braille_supported?}
+        make_setting(p_("Settings", "Enable braille output"), :bool, "Interface", "EnableBraille") if SpeechOutput.list.any?{|output| output.braille_supported?}
         make_setting(p_("Settings", "Use a voice dictionary when processing characters (requires NVDA addon when using NVDA as a speech output)"), :bool, "Voice", "UseVoiceDictionary")
                         make_setting(p_("Settings", "Typing echo"), [p_("Settings", "Characters"),p_("Settings", "Words"),p_("Settings", "Characters and words"),p_("Settings", "None")], "Interface", "TypingEcho")
         on_load {

--- a/src/scenes/sounds.rb
+++ b/src/scenes/sounds.rb
@@ -116,10 +116,10 @@ class Scene_Sounds
                         @name=@name[0..255] if @name.size>255
         n=@name.split(" ")
         ind=n.size
-        for i in 0...n.size
+        (0...n.size).each do |i|
           ind=i if n[i].downcase=='by'
           end
-        for i in 0...n.size
+        (0...n.size).each do |i|
                     break if i==ind
                     s=n[i]
                               t=s.split("")[0].upcase+s.split("")[1..-1].join.downcase
@@ -131,7 +131,7 @@ class Scene_Sounds
                 end
       end
         @snd=[]
-    for file in @soundnames.keys.sort
+    @soundnames.keys.sort.each do |file|
           @snd.push(Struct_Sounds_Sound.new(file,@soundnames[file],@theme))
     end
     return $scene=Scene_Main.new if @snd.size==0
@@ -288,7 +288,7 @@ form.resume
     waiting {
     magic="EltenSoundThemePackageFileCMPSMC"
 cnt=""
-    for s in @snd
+    @snd.each do |s|
             begin
             snd=s.sound(true)
             rescue Exception => e
@@ -330,7 +330,7 @@ id=id.delspecial
 @form.focus
         return
       end
-      for st in std
+      std.each do |st|
         if st.file.downcase==id.downcase+".elsnd" && st.user!=Session.name
 alert(p_("Sounds", "Sound theme with that ID already exists."))
 @form.focus

--- a/src/scenes/soundthemes.rb
+++ b/src/scenes/soundthemes.rb
@@ -11,7 +11,7 @@ st=Dir.entries(Dirs.soundthemes)
 st.delete("..")
 st.delete(".")
 @soundthemes = []
-for s in st
+st.each do |s|
       f=EltenPath.join(Dirs.soundthemes, s)
       if File.file?(f) && File.extname(f).downcase==".elsnd"
         t=load_soundtheme(f, false)
@@ -117,7 +117,7 @@ std = @std.select{|s|s.user==category}.sort_by{|s|s.time}.reverse
 end
       sts=std.map{|s|
       status=p_("SoundThemes", "Not downloaded")
-      for st in @soundthemes
+      @soundthemes.each do |st|
         next if st.file==nil
         if File.basename(st.file)==File.basename(s.file)
             if s.stamp.to_i>st.stamp.to_i

--- a/src/scenes/speedtest.rb
+++ b/src/scenes/speedtest.rb
@@ -45,7 +45,7 @@ result = "#{p_("SpeedTest", "Average time")}: #{((times.sum).to_f / (n-errors.to
 #{p_("SpeedTest", "Errors count")}: #{errors}
 
 "
-      for i in 0...n
+      (0...n).each do |i|
         result+=(i+1).to_s+". "+(times[i]*1000).round.to_s+"ms\r\n"
         end
       input_text(p_("SpeedTest", "Test results"),flags: EditBox::Flags::ReadOnly,text: result)

--- a/src/scenes/users.rb
+++ b/src/scenes/users.rb
@@ -29,7 +29,7 @@ class Scene_Users
           return
     end
         selt = []
-    for i in 0..usr.size - 1
+    (0..usr.size - 1).each do |i|
       selt[i] = user_with_status(usr[i])
       end
     @sel = ListBox.new(selt,header: p_("Users", "List of users"), index: 0, flags: 0, quiet: false)

--- a/src/scenes/users_recentlyactived.rb
+++ b/src/scenes/users_recentlyactived.rb
@@ -14,7 +14,7 @@ class Scene_Users_RecentlyActived
       alert(_("Error"))
     end
             selt = []
-    for i in 0..onl.size - 1
+    (0..onl.size - 1).each do |i|
       selt[i] = user_with_status(onl[i])
       end
     @sel = ListBox.new(selt,header: p_("Users_RecentlyActived", "Recently active users"), index: 0, flags: 0, quiet: false)

--- a/src/scenes/users_recentlyregistered.rb
+++ b/src/scenes/users_recentlyregistered.rb
@@ -14,7 +14,7 @@ class Scene_Users_RecentlyRegistered
       alert(_("Error"))
     end
             selt = []
-    for i in 0..onl.size - 1
+    (0..onl.size - 1).each do |i|
       selt[i] = user_with_status(onl[i])
       end
     @sel = ListBox.new(selt,header: p_("Users_RecentlyRegistered", "Recently registered users"), index: 0, flags: 0, quiet: false)

--- a/src/scenes/usersaddedmetocontacts.rb
+++ b/src/scenes/usersaddedmetocontacts.rb
@@ -22,7 +22,7 @@ class Scene_Users_AddedMeToContacts
         alert(_("Error"))
       end
     selt = []
-    for i in 0..usr.size - 1
+    (0..usr.size - 1).each do |i|
       selt[i] = user_with_status(usr[i])
       end
     header=p_("UsersAddedMeToContacts", "Users who added me to their contacts list")

--- a/src/scenes/usersearch.rb
+++ b/src/scenes/usersearch.rb
@@ -28,7 +28,7 @@ if @results.size==0
   return
 end
 selt=[]
-for r in @results
+@results.each do |r|
   selt.push(user_with_status(r, true, true, "\r\n"))
   end
 @sel=ListBox.new(selt,header: p_("UserSearch", "Found items"), index: 0, flags: 0, quiet: false)


### PR DESCRIPTION
## Summary

- **Bug fixes**: Fix typo `errror`→`error` in crash dialog, add missing `call_context(:waiting_end)` in API timeout path (context leak), fix macOS CMake deployment target from non-existent `26.0` to `13.0`
- **Refactor**: Convert ~495 `for VAR in EXPR` loops to idiomatic `EXPR.each do |VAR|` across all 58 Ruby source files
- **macOS Braille support**: New `OSXVoiceOverBridge` module + `OSXVoiceOverOutput` class that sends text to any connected Braille display via VoiceOver's `AXPostNotification` (ApplicationServices.framework, no native extensions required); braille setting in UI now visible on macOS too
- **GitHub Actions**: New `.github/workflows/release.yml` — on any `v*` tag, builds Windows x64/x86/arm64 launchers + installer (`EltenSetup.exe`) and macOS arm64 package (`Elten.pkg`), then creates a GitHub Release with both attached; pre-release flag set automatically for beta/alpha/rc tags

## Test plan

- [ ] Build on Windows (x64, x86, arm64) — launcher compiles, installer produced
- [ ] Build on macOS arm64 — launcher and `.pkg` produced
- [ ] Run Elten on macOS with VoiceOver enabled — confirm braille output appears on Braille display / VoiceOver announcement
- [ ] Run Elten on macOS with VoiceOver off — confirm braille methods are no-ops
- [ ] Push a `v*` tag to a fork and verify GitHub Actions produces release artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)