### PR TITLE
Add toggleable previews to the sound theme editor

### DIFF
--- a/src/scenes/sounds.rb
+++ b/src/scenes/sounds.rb
@@ -151,6 +151,7 @@ class Scene_Sounds
         @btn_close = Button.new(p_("Sounds", "Close"))
     ]
           a=nil
+          playing_sound=nil
     @form=Form.new(@fields, index: 0, silent: false, quiet: true)
     if @theme==nil
       @form.hide(@btn_playorig)
@@ -162,25 +163,32 @@ class Scene_Sounds
       end
     @btn_play.on(:press) {
               a.close if a!=nil
+              playing_sound=nil
               snd=@snd[@sel.index].sound
               if snd!=nil
               a=Sound.new(stream: snd)
               a.volume=0.01*Configuration.volume
                 a.play
+                playing_sound=[@sel.index, :sound]
                 end
     }
     @btn_playorig.on(:press) {
               a.close if a!=nil
+              playing_sound=nil
               snd=@snd[@sel.index].original
               if snd!=nil
               a=Sound.new(stream: snd)
               a.volume=0.01*Configuration.volume
                 a.play
+                playing_sound=[@sel.index, :original]
                 end
     }
     @sel.on(:key_space) {|prm|
     key_shift = prm[0]
-    if !key_shift
+    selected_sound=[@sel.index, key_shift ? :original : :sound]
+    if a!=nil && a.playing? && playing_sound==selected_sound
+    @btn_stop.press
+  elsif !key_shift
     @btn_play.press
   else
     @btn_playorig.press
@@ -190,6 +198,7 @@ class Scene_Sounds
     if a!=nil
                   a.close
                   a=nil
+                  playing_sound=nil
                 end
     }
     @btn_extract.on(:press) {extract}
@@ -204,7 +213,25 @@ class Scene_Sounds
     @form.focus
     }
     @btn_change.on(:press) {
-                    file=get_file(p_("Sounds", "Select new sound"), path: "", save: false, extensions: [".ogg", ".mp3", ".wav", ".opus", ".aac", ".wma", ".m4a",".flac",".aiff"])
+                    a.close if a!=nil
+                    a=nil
+                    playing_sound=nil
+                    preview_file=nil
+                    file=get_file(p_("Sounds", "Select new sound"), path: "", save: false, extensions: [".ogg", ".mp3", ".wav", ".opus", ".aac", ".wma", ".m4a",".flac",".aiff"], space_action: Proc.new {|selected|
+                      if a!=nil && preview_file==selected && a.playing?
+                        a.close
+                        a=nil
+                        preview_file=nil
+                      elsif File.file?(selected)
+                        a.close if a!=nil
+                        a=Sound.new(selected)
+                        a.volume=0.01*Configuration.volume
+                        a.play
+                        preview_file=selected
+                      end
+                    })
+                    a.close if a!=nil
+                    a=nil
                 loop_update
 if file!=nil
   snd=Sound.new(file)

--- a/src/ui/controls/tree.rb
+++ b/src/ui/controls/tree.rb
@@ -197,7 +197,7 @@ lsel = ListBox.new(options, header: "", index: 0, flags: ListBox::Flags::AnyDir)
      # @param save [Boolean] hides a files, presents only directories
      # @param file [String] a file to focus
      # @return [String] an absolute path to a selected file or directory
-     def get_file(header="", path: "", save: false, extensions: nil)
+     def get_file(header="", path: "", save: false, extensions: nil, space_action: nil)
               dialog_open
        loop_update
        ft=FilesTree.new(header, path: path, hide_files: save, quiet: true, extensions: extensions)
@@ -234,9 +234,13 @@ lsel = ListBox.new(options, header: "", index: 0, flags: ListBox::Flags::AnyDir)
            end
          end
          if key_pressed?(:key_space)
+           if space_action!=nil
+             space_action.call(ft.selected(true))
+           else
            pt=ft.path
            ftp=input_text(p_("EAPI_Form", "Choose a path"), text: ft.path, escapable: true)
            ft.path=ftp if ftp!=nil and File.directory?(ftp)
+           end
          end
        end
               rescue Exception


### PR DESCRIPTION
Space previews the focused audio file when selecting a replacement sound for a sound theme. Pressing Space again stops playback, and selecting another file switches the preview.

Space and Shift+Space on the sound list now also stop the currently playing sound when pressed again.

Forum thread: https://elten.link/pl/forum/thread/21752