### PR TITLE
Add Ctrl+- shortcut for deleting forum threads

### DIFF
--- a/src/scenes/forum.rb
+++ b/src/scenes/forum.rb
@@ -2189,7 +2189,7 @@ threadopen(@thrsel.index)
             end
           end
         }
-        m.option(p_("Forum", "Delete thread")) {
+        m.option(p_("Forum", "Delete thread"), nil, "-") {
           confirm(p_("Forum", "Do you really want to delete thread %{thrname}?")%{ :thrname => @sthreads[@thrsel.index].name }) do
             if forum_attempt(nil) {
               EltenLink::Forum.delete_thread(elten_link, thread_id: @sthreads[@thrsel.index].id)


### PR DESCRIPTION
Ctrl+- now runs the existing thread removal action when moderation options are available. The existing Ctrl+- shortcut for deleting posts remains unchanged.

Forum thread: https://elten.link/pl/forum/thread/27302