### PR TITLE
Add a voice message recording shortcut

### DIFF
--- a/src/scenes/messages.rb
+++ b/src/scenes/messages.rb
@@ -977,6 +977,7 @@ def audiolimit
 @polls=[]
                                  loop do                     
              loop_update
+             @form.fields[3].start_recording if main_shortcut_pressed?("r", shift: true)
              notempt = (@form.fields[2].is_a?(EditBox) && @form.fields[2].text!="") || (@form.fields[3].is_a?(OpusRecordButton) && !@form.fields[3].empty?)
              notempt=true if @form.fields[2]==nil and @form.fields[3]==nil
                           if @form.fields[4]==nil && notempt

--- a/src/ui/controls/opus_record_button.rb
+++ b/src/ui/controls/opus_record_button.rb
@@ -407,6 +407,11 @@ form.resume
         @form.index=0
         @form.wait
       end
+      def start_recording
+        @btn_record.press
+        @form.index = @recorder == nil ? @btn_record : @btn_pause
+        @form.wait
+      end
       def empty?
         @status==0
       end


### PR DESCRIPTION
This change adds Ctrl+Shift+R to immediately start recording a voice message from the message composer, as requested in the forum thread.

Forum thread: https://elten.link/pl/forum/thread/22570