### PR TITLE
macOS: VoiceOver as selectable speech output + Braille; bug fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ if(CMAKE_GENERATOR MATCHES "Visual Studio")
 endif()
 
 if(APPLE AND NOT DEFINED CMAKE_OSX_DEPLOYMENT_TARGET)
-  set(CMAKE_OSX_DEPLOYMENT_TARGET "26.0" CACHE STRING "Minimum macOS deployment target")
+  set(CMAKE_OSX_DEPLOYMENT_TARGET "13.0" CACHE STRING "Minimum macOS deployment target")
 endif()
 
 project(EltenLauncher LANGUAGES CXX)

--- a/src/eltenlink/client.rb
+++ b/src/eltenlink/client.rb
@@ -166,7 +166,6 @@ module EltenLink
         @context == nil ? sleep(0.01) : call_context(:loop_update, false)
         if timeout != nil && Time.now.to_f - started > timeout.to_f
           @last_error = Error.timeout(module_name: safe_request_path)
-          call_context(:waiting_end)
           break
         end
       end

--- a/src/eltenlink/client.rb
+++ b/src/eltenlink/client.rb
@@ -166,6 +166,7 @@ module EltenLink
         @context == nil ? sleep(0.01) : call_context(:loop_update, false)
         if timeout != nil && Time.now.to_f - started > timeout.to_f
           @last_error = Error.timeout(module_name: safe_request_path)
+          call_context(:waiting_end)
           break
         end
       end

--- a/src/main.rb
+++ b/src/main.rb
@@ -142,7 +142,7 @@ terminate_process_handle(o)
         speak("Critical error occurred: "+$!.message)
     speech_wait
     sleep(0.5)
-    speak("Do you want to send the errror report?")
+    speak("Do you want to send the error report?")
     speech_wait
     if selector(["No","Yes"])== 1
       sleep(0.15)

--- a/src/platforms/osx/eapi/voiceover.rb
+++ b/src/platforms/osx/eapi/voiceover.rb
@@ -2,9 +2,9 @@
 # Copyright (C) 2026 Dawid Pieper
 # Elten is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 3.
 
-# VoiceOver braille bridge for macOS.
-# Uses ApplicationServices AXPostNotification with kAXAnnouncementRequestedNotification
-# so that VoiceOver speaks and mirrors text on any connected Braille display.
+# VoiceOver bridge for macOS.
+# Uses ApplicationServices AXPostNotification with AXAnnouncementRequested
+# so that VoiceOver speaks the text and mirrors it on any connected Braille display.
 
 module OSXVoiceOverBridge
   PTR  = Fiddle::TYPE_VOIDP
@@ -25,13 +25,13 @@ module OSXVoiceOverBridge
       false
     end
 
-    # Send text as a VoiceOver announcement.
-    # VoiceOver will both speak it and show it on any connected Braille display.
-    def announce(text)
+    # Send text to VoiceOver. VoiceOver speaks it and mirrors it on Braille displays.
+    # Priority 90 (NSAccessibilityPriorityHigh) interrupts the current VoiceOver output.
+    def announce(text, priority: 90)
       return false unless voiceover_running?
       app_el = ax_ui_element_create_application.call(Process.pid)
       return false if app_el.to_i == 0
-      info = build_announcement_dict(text.to_s)
+      info = build_announcement_dict(text.to_s, priority)
       ax_post_notification.call(app_el, nsstring("AXAnnouncementRequested"), info)
       true
     rescue Exception => e
@@ -43,7 +43,6 @@ module OSXVoiceOverBridge
 
     def app_services
       return @app_services if defined?(@app_services)
-      # AppKit must be loaded first so NSObject etc. are available
       Fiddle.dlopen("/System/Library/Frameworks/AppKit.framework/AppKit") rescue nil
       @app_services = Fiddle.dlopen("/System/Library/Frameworks/ApplicationServices.framework/ApplicationServices")
     rescue Exception
@@ -56,8 +55,6 @@ module OSXVoiceOverBridge
     rescue Exception
       @objc = nil
     end
-
-    # --- Objective-C helpers (same pattern as OSXSpeechBridge) ---
 
     def objc_msg_send(types, ret)
       @objc_msg_send ||= {}
@@ -100,24 +97,19 @@ module OSXVoiceOverBridge
       send_id(cls("NSNumber"), "numberWithInt:", value.to_i, [INT])
     end
 
-    # Build NSDictionary: { AXAnnouncement => text, AXPriority => 90 }
-    # AXPriority 90 = NSAccessibilityPriorityHigh (interrupts current VoiceOver output)
-    def build_announcement_dict(text)
+    def build_announcement_dict(text, priority)
       keys   = ns_mutable_array([nsstring("AXAnnouncement"), nsstring("AXPriority")])
-      values = ns_mutable_array([nsstring(text), nsnumber_int(90)])
+      values = ns_mutable_array([nsstring(text), nsnumber_int(priority)])
       send_id(cls("NSDictionary"), "dictionaryWithObjects:forKeys:count:",
               values, keys, 2, [PTR, PTR, PTR])
     end
 
     def ns_mutable_array(items)
       array = send_id(cls("NSMutableArray"), "array")
-      items.each do |item|
-        send_void(array, "addObject:", item, [PTR])
-      end
+      items.each { |item| send_void(array, "addObject:", item, [PTR]) }
       array
     end
 
-    # --- ApplicationServices functions ---
 
     def ax_is_voiceover_enabled
       @ax_is_voiceover_enabled ||= Fiddle::Function.new(
@@ -144,9 +136,14 @@ module OSXVoiceOverBridge
   end
 end
 
-# SpeechOutput subclass that provides Braille output via VoiceOver on macOS.
-# It has no speech voices – it is purely a Braille channel.
+# SpeechOutput that routes speech through VoiceOver via the Accessibility API.
+# When selected, VoiceOver speaks the text with its own voice and simultaneously
+# shows it on any connected Braille display — no separate Braille configuration needed.
 class OSXVoiceOverOutput < SpeechOutput
+  VOICE_ID   = "voiceover://system"
+  VOICE_NAME = "VoiceOver"
+
+
   class << self
     def available?
       OSXVoiceOverBridge.available?
@@ -160,34 +157,90 @@ class OSXVoiceOverOutput < SpeechOutput
       false
     end
 
-    # Do not auto-select as speech output
+    # Never selected automatically — user must choose it explicitly.
     def default?
       false
     end
 
-    # No speech voices – this output only handles Braille
     def voices
-      []
+      return [] unless available?
+      [SpeechOutput::Voice.new(
+        id:     VOICE_ID,
+        name:   VOICE_NAME,
+        output: self,
+        native: nil
+      )]
+    end
+
+    def apply_voice(_voice)
+      true
+    end
+
+    def speak_text(text, method: 1, spelling: false, interrupt: true, pitch: 50)
+      return 1 unless usable?
+      text = text.to_s.chars.join(" ") if spelling
+      OSXVoiceOverBridge.announce(text.to_s)
+      0
+    rescue Exception => e
+      Log.warning("OSXVoiceOverOutput.speak_text: #{e.class}: #{e.message}") if defined?(Log)
+      1
+    end
+
+    def stop
+      # Post an empty announcement to interrupt whatever VoiceOver is currently saying.
+      OSXVoiceOverBridge.announce("​") if usable?
+      0
+    rescue Exception
+      1
+    end
+
+    # VoiceOver manages its own speaking state; we cannot query it externally.
+    def speaking?
+      false
     end
 
     def braille_supported?
       true
     end
 
-    def braille(_text, _pos = nil, _push = false, _type = 0, _index = nil, _cursor = nil)
-      return if Configuration.enablebraille == 0
-      return unless usable?
-      OSXVoiceOverBridge.announce(_text.to_s)
+    # Braille output is automatic: VoiceOver mirrors speech to Braille displays.
+    def braille(text, _pos = nil, _push = false, _type = 0, _index = nil, _cursor = nil)
+      return unless Configuration.enablebraille == 1 && usable?
+      OSXVoiceOverBridge.announce(text.to_s)
     rescue Exception => e
       Log.warning("OSXVoiceOverOutput.braille: #{e.class}: #{e.message}") if defined?(Log)
     end
 
     def braille_alert(text)
-      return if Configuration.enablebraille == 0
-      return unless usable?
+      return unless Configuration.enablebraille == 1 && usable?
       OSXVoiceOverBridge.announce(text.to_s)
     rescue Exception => e
       Log.warning("OSXVoiceOverOutput.braille_alert: #{e.class}: #{e.message}") if defined?(Log)
+    end
+
+    # VoiceOver controls rate, volume, and pitch through its own settings.
+    def rate_supported?
+      false
+    end
+
+    def volume_supported?
+      false
+    end
+
+    def pitch_supported?
+      false
+    end
+
+    def pause_supported?
+      false
+    end
+
+    def indexed_supported?
+      false
+    end
+
+    def spelling_supported?
+      true
     end
   end
 end

--- a/src/platforms/osx/eapi/voiceover.rb
+++ b/src/platforms/osx/eapi/voiceover.rb
@@ -129,6 +129,33 @@ module OSXVoiceOverBridge
       )
     end
 
+    # Simulate a Control key press+release via CoreGraphics to interrupt VoiceOver.
+    # VoiceOver treats the Control key as its universal "stop speaking" command.
+    def stop_speech
+      return false unless voiceover_running?
+      cg = core_graphics
+      return false if cg == nil
+      kVK_Control      = 0x3B
+      kCGHIDEventTap   = 0
+      create_kb_event  = Fiddle::Function.new(cg["CGEventCreateKeyboardEvent"], [PTR, INT, INT], PTR)
+      post_event       = Fiddle::Function.new(cg["CGEventPost"], [INT, PTR], VOID)
+      key_down = create_kb_event.call(0, kVK_Control, 1)
+      key_up   = create_kb_event.call(0, kVK_Control, 0)
+      post_event.call(kCGHIDEventTap, key_down)
+      post_event.call(kCGHIDEventTap, key_up)
+      true
+    rescue Exception => e
+      log_warning("stop_speech failed: #{e.class}: #{e.message}")
+      false
+    end
+
+    def core_graphics
+      return @core_graphics if defined?(@core_graphics)
+      @core_graphics = Fiddle.dlopen("/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics")
+    rescue Exception
+      @core_graphics = nil
+    end
+
     def log_warning(msg)
       Log.warning("OSXVoiceOverBridge: #{msg}") if defined?(Log)
     rescue Exception
@@ -187,8 +214,7 @@ class OSXVoiceOverOutput < SpeechOutput
     end
 
     def stop
-      # Post an empty announcement to interrupt whatever VoiceOver is currently saying.
-      OSXVoiceOverBridge.announce("​") if usable?
+      OSXVoiceOverBridge.stop_speech if usable?
       0
     rescue Exception
       1

--- a/src/platforms/osx/eapi/voiceover.rb
+++ b/src/platforms/osx/eapi/voiceover.rb
@@ -231,14 +231,14 @@ class OSXVoiceOverOutput < SpeechOutput
 
     # Braille output is automatic: VoiceOver mirrors speech to Braille displays.
     def braille(text, _pos = nil, _push = false, _type = 0, _index = nil, _cursor = nil)
-      return unless Configuration.enablebraille == 1 && usable?
+      return unless Configuration.enablebraille && usable?
       OSXVoiceOverBridge.announce(text.to_s)
     rescue Exception => e
       Log.warning("OSXVoiceOverOutput.braille: #{e.class}: #{e.message}") if defined?(Log)
     end
 
     def braille_alert(text)
-      return unless Configuration.enablebraille == 1 && usable?
+      return unless Configuration.enablebraille && usable?
       OSXVoiceOverBridge.announce(text.to_s)
     rescue Exception => e
       Log.warning("OSXVoiceOverOutput.braille_alert: #{e.class}: #{e.message}") if defined?(Log)

--- a/src/platforms/osx/eapi/voiceover.rb
+++ b/src/platforms/osx/eapi/voiceover.rb
@@ -131,18 +131,20 @@ module OSXVoiceOverBridge
 
     # Simulate a Control key press+release via CoreGraphics to interrupt VoiceOver.
     # VoiceOver treats the Control key as its universal "stop speaking" command.
+    # kCGSessionEventTap scopes the event to the current login session rather than
+    # the raw HID stream, so it cannot reach apps in other user sessions.
     def stop_speech
       return false unless voiceover_running?
       cg = core_graphics
       return false if cg == nil
-      kVK_Control      = 0x3B
-      kCGHIDEventTap   = 0
-      create_kb_event  = Fiddle::Function.new(cg["CGEventCreateKeyboardEvent"], [PTR, INT, INT], PTR)
-      post_event       = Fiddle::Function.new(cg["CGEventPost"], [INT, PTR], VOID)
-      key_down = create_kb_event.call(0, kVK_Control, 1)
-      key_up   = create_kb_event.call(0, kVK_Control, 0)
-      post_event.call(kCGHIDEventTap, key_down)
-      post_event.call(kCGHIDEventTap, key_up)
+      kVK_Control          = 0x3B
+      kCGSessionEventTap   = 1
+      key_down = cg_create_kb_event.call(0, kVK_Control, 1)
+      key_up   = cg_create_kb_event.call(0, kVK_Control, 0)
+      cg_post_event.call(kCGSessionEventTap, key_down)
+      cg_post_event.call(kCGSessionEventTap, key_up)
+      cf_release.call(key_down)
+      cf_release.call(key_up)
       true
     rescue Exception => e
       log_warning("stop_speech failed: #{e.class}: #{e.message}")
@@ -154,6 +156,21 @@ module OSXVoiceOverBridge
       @core_graphics = Fiddle.dlopen("/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics")
     rescue Exception
       @core_graphics = nil
+    end
+
+    def cg_create_kb_event
+      @cg_create_kb_event ||= Fiddle::Function.new(core_graphics["CGEventCreateKeyboardEvent"], [PTR, INT, INT], PTR)
+    end
+
+    def cg_post_event
+      @cg_post_event ||= Fiddle::Function.new(core_graphics["CGEventPost"], [INT, PTR], VOID)
+    end
+
+    def cf_release
+      @cf_release ||= Fiddle::Function.new(
+        Fiddle.dlopen("/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation")["CFRelease"],
+        [PTR], VOID
+      )
     end
 
     def log_warning(msg)
@@ -203,7 +220,7 @@ class OSXVoiceOverOutput < SpeechOutput
       true
     end
 
-    def speak_text(text, method: 1, spelling: false, interrupt: true, pitch: 50)
+    def speak_text(text, method: 1, spelling: false, _interrupt: true, _pitch: 50)
       return 1 unless usable?
       text = text.to_s.chars.join(" ") if spelling
       OSXVoiceOverBridge.announce(text.to_s)

--- a/src/scenes/settings.rb
+++ b/src/scenes/settings.rb
@@ -355,7 +355,7 @@ def make_window
           make_setting(braille_label, :bool, "Interface", "EnableBraille")
         end
         make_setting(p_("Settings", "Use a voice dictionary when processing characters (requires NVDA addon when using NVDA as a speech output)"), :bool, "Voice", "UseVoiceDictionary")
-                        make_setting(p_("Settings", "Typing echo"), [p_("Settings", "Characters"),p_("Settings", "Words"),p_("Settings", "Characters and words"),p_("Settings", "None")], "Interface", "TypingEcho")
+                        make_setting(p_("Settings", "Typing echo"), [p_("Settings", "Characters"),p_("Settings", "Words"),p_("Settings", "Characters and words"),p_("Settings", "None")], "Interface", "TypingEcho", ["characters", "words", "characters_and_words", "none"])
         on_load {
         voice_output=Proc.new {
           voice=voicesmapping[@form.fields[1].index].to_s

--- a/src/scenes/settings.rb
+++ b/src/scenes/settings.rb
@@ -346,9 +346,16 @@ def make_window
         make_setting(p_("Settings", "Speech rate"), (0..100).to_a.reverse.map{|x|x.to_s+"%"}, "Voice", "Rate", (0..100).to_a.reverse)
         make_setting(p_("Settings", "Speech volume"), (5..100).to_a.reverse.map{|x|x.to_s+"%"}, "Voice", "Volume", (5..100).to_a.reverse)
         make_setting(p_("Settings", "Speech pitch"), (0..100).to_a.reverse.map{|x|x.to_s+"%"}, "Voice", "Pitch", (0..100).to_a.reverse)
-        make_setting(p_("Settings", "Enable braille output"), :bool, "Interface", "EnableBraille") if SpeechOutput.list.any?{|output| output.braille_supported?}
-        make_setting(p_("Settings", "Use a voice dictionary when processing characters (requires the NVDA add-on when using NVDA for speech output)"), :bool, "Voice", "UseVoiceDictionary")
-                        make_setting(p_("Settings", "Typing echo"), [p_("Settings", "Characters"),p_("Settings", "Words"),p_("Settings", "Characters and words"),p_("Settings", "None")], "Interface", "TypingEcho", ["characters", "words", "characters_and_words", "none"])
+        if SpeechOutput.list.any? { |output| output.braille_supported? }
+          braille_label = if defined?(OSXVoiceOverOutput) && OSXVoiceOverOutput.available?
+            p_("Settings", "Enable braille output")
+          else
+            p_("Settings", "Enable braille output (requires NVDA addon)")
+          end
+          make_setting(braille_label, :bool, "Interface", "EnableBraille")
+        end
+        make_setting(p_("Settings", "Use a voice dictionary when processing characters (requires NVDA addon when using NVDA as a speech output)"), :bool, "Voice", "UseVoiceDictionary")
+                        make_setting(p_("Settings", "Typing echo"), [p_("Settings", "Characters"),p_("Settings", "Words"),p_("Settings", "Characters and words"),p_("Settings", "None")], "Interface", "TypingEcho")
         on_load {
         voice_output=Proc.new {
           voice=voicesmapping[@form.fields[1].index].to_s


### PR DESCRIPTION
## Summary

This PR contains two independent groups of changes.

---

### 1. Bug fixes (commit `1b19662`)

- **Typo fix in `src/main.rb`** — `errror` → `error` in crash report dialog
- **Missing `call_context` in `src/eltenlink/client.rb`** — `call_context(:waiting_end)` was missing in the API binary payload timeout path, causing a context leak
- **macOS CMake deployment target (`CMakeLists.txt`)** — `CMAKE_OSX_DEPLOYMENT_TARGET` was set to non-existent `26.0`, corrected to `13.0` (macOS Ventura)

---

### 2. macOS VoiceOver as selectable speech output with Braille (commits `87c9a4d`, `be26f78`)

#### Background

On macOS, Apple offers two separate TTS mechanisms:

- **System voices** (`NSSpeechSynthesizer` / `AVSpeechSynthesizer`) — pure audio synthesis, no screen reader involvement, no Braille output
- **VoiceOver** (Accessibility API / `ApplicationServices.framework`) — the system screen reader; apps post an `AXAnnouncementRequested` notification via `AXPostNotification()`, VoiceOver receives it and simultaneously (a) speaks the text with its own TTS voice (configurable in VoiceOver Utility) and (b) routes it to every connected Braille display through its internal BrailleDriver

Previously, Elten on macOS only used system voices. Users with a Braille display had no way to receive Braille output.

#### What was added

**New file: `src/platforms/osx/eapi/voiceover.rb`** (`:osx` only)

- `OSXVoiceOverBridge` — Fiddle wrapper around `ApplicationServices.framework` and `CoreGraphics.framework`:
  - `AXIsVoiceOverEnabled()` — checks if VoiceOver is currently running
  - `announce(text)` — posts `AXAnnouncementRequested` with `NSAccessibilityPriorityHigh` (90); interrupts whatever VoiceOver is currently saying
  - `stop_speech` — simulates a Control key press+release via `CGEventPost(kCGHIDEventTap, …)`; VoiceOver treats the Control key as its universal "stop speaking" command
- `OSXVoiceOverOutput < SpeechOutput` — full `SpeechOutput` subclass:
  - Exposes a single voice entry **"VoiceOver"** in Settings → Voice
  - `available?` — true when `ApplicationServices` loads (always on macOS 10.9+)
  - `usable?` — true only while VoiceOver is actively running
  - `speak_text` → `AXAnnouncementRequested`; VoiceOver speaks and mirrors to Braille automatically
  - `stop` → `CGEventPost` Control key press; clean interrupt with no Braille display artifact
  - `braille_supported?` → `true`; `braille` / `braille_alert` also post via VoiceOver

**`filelist`** — `src/platforms/osx/eapi/voiceover.rb :osx` added after `speech.rb`

**`src/scenes/settings.rb`** — Braille toggle label no longer says "requires NVDA addon" on macOS; detects `OSXVoiceOverOutput` and shows the correct platform label

#### Voice selection matrix

| Voice selected | Speech engine | Braille |
|---|---|---|
| System voice (Alex, Luca, …) | `NSSpeechSynthesizer` → direct audio | ✗ |
| **VoiceOver** | VoiceOver's own TTS | ✓ automatic via VoiceOver BrailleDriver |

---

## What is still missing / known limitations

### Braille for non-speech control events
`src/eapi/controls.rb` has many `NVDA.braille(...)` calls (editbox cursor, list position, focus changes). These are Windows/NVDA-only. On macOS, VoiceOver only receives text routed through `speak_text` — editbox content and list positions are **not** sent to the Braille display from Elten's side. A platform-agnostic `braille_output` abstraction (mirroring `speech_output` in `eapi/speech.rb`) would be needed to wire those calls to `OSXVoiceOverOutput.braille()` on macOS.

### `speaking?` always returns `false`
No callback or polling mechanism exists to know when VoiceOver finishes an announcement. `speech_wait` and `alert(..., wait: true)` return immediately when VoiceOver is the active output.

### Rate / volume / pitch not controllable
VoiceOver's voice settings live in VoiceOver Utility / System Settings → Accessibility → VoiceOver. There is no public API to read or write them programmatically. The sliders in Settings → Voice are correctly hidden for the VoiceOver output.

### Voice list not dynamically updated
If VoiceOver is toggled on/off after startup, the voice entry remains visible. `usable?` checks the live state at call time, so speech calls fail silently when VoiceOver is off — but the list entry does not disappear.

### "VoiceOver" voice name not localised
The name is hardcoded in English and should be wrapped in `p_(...)` once a translation context is agreed on.

---

## Test plan

- [ ] Build on macOS — confirm CMake no longer warns about unknown deployment target
- [ ] Open Settings → Voice — confirm "VoiceOver" appears in the voice list on macOS
- [ ] Select "VoiceOver" with VoiceOver running — confirm speech is announced through VoiceOver and appears on connected Braille display
- [ ] Navigate away mid-sentence — confirm VoiceOver stops cleanly (Ctrl key simulated)
- [ ] Select "VoiceOver" with VoiceOver off — confirm silent failure (no crash)
- [ ] Select a system voice — confirm audio speech works as before, no Braille output
- [ ] Check Braille toggle label on macOS — should say "Enable braille output" without the NVDA note
- [ ] Build/run on Windows — confirm no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)