### PR TITLE
Add GitHub Actions release workflow for Windows and macOS

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,120 @@
+name: Build and Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  build-windows:
+    name: Build Windows (${{ matrix.preset }})
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        preset: [windows-x64, windows-x86, windows-arm64]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Inno Setup
+        run: choco install innosetup --no-progress -y
+
+      - name: Configure (${{ matrix.preset }})
+        run: cmake --preset ${{ matrix.preset }}
+
+      - name: Build launcher (${{ matrix.preset }})
+        run: cmake --build --preset ${{ matrix.preset }} --target EltenLauncher --config Release
+
+      - name: Upload launcher artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: launcher-${{ matrix.preset }}
+          path: build/release/windows/
+
+  build-windows-installer:
+    name: Build Windows Installer
+    runs-on: windows-latest
+    needs: build-windows
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Inno Setup
+        run: choco install innosetup --no-progress -y
+
+      - name: Download x64 launcher
+        uses: actions/download-artifact@v4
+        with:
+          name: launcher-windows-x64
+          path: build/release/windows/
+
+      - name: Configure (windows-x64 for installer)
+        run: cmake --preset windows-x64
+
+      - name: Build installer
+        run: cmake --build --preset windows-x64 --target EltenPkg --config Release
+
+      - name: Upload Windows installer
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-installer
+          path: dist/windows/EltenSetup.exe
+
+  build-macos:
+    name: Build macOS (arm64)
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install build dependencies
+        run: brew install cmake
+
+      - name: Configure (osx-arm64)
+        run: cmake --preset osx-arm64
+
+      - name: Build launcher (osx-arm64)
+        run: cmake --build --preset osx-arm64 --target EltenLauncher
+
+      - name: Build macOS package
+        run: cmake --build --preset osx-arm64 --target EltenPkg
+
+      - name: Upload macOS package
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-package
+          path: dist/osx/Elten.pkg
+
+  release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    needs: [build-windows-installer, build-macos]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download Windows installer
+        uses: actions/download-artifact@v4
+        with:
+          name: windows-installer
+          path: artifacts/
+
+      - name: Download macOS package
+        uses: actions/download-artifact@v4
+        with:
+          name: macos-package
+          path: artifacts/
+
+      - name: Extract version from tag
+        id: version
+        run: echo "version=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: Elten ${{ steps.version.outputs.version }}
+          draft: false
+          prerelease: ${{ contains(github.ref, 'beta') || contains(github.ref, 'alpha') || contains(github.ref, 'rc') }}
+          generate_release_notes: true
+          files: |
+            artifacts/EltenSetup.exe
+            artifacts/Elten.pkg


### PR DESCRIPTION
## Summary

New `.github/workflows/release.yml` that fires on any `v*` tag push:

- Builds Windows launchers for x64, x86, and arm64 in parallel using VS 2022
- Assembles Windows installer (`EltenSetup.exe`) via Inno Setup
- Builds macOS arm64 package (`Elten.pkg`) on `macos-14`
- Creates a GitHub Release with both artifacts attached; pre-release flag is set automatically for beta/alpha/rc tags

## Test plan

- [ ] Push a `v*` tag to a fork and verify the workflow triggers
- [ ] Confirm Windows x64/x86/arm64 launchers and installer are produced
- [ ] Confirm macOS arm64 `.pkg` is produced
- [ ] Confirm a GitHub Release is created with both artifacts attached
- [ ] Push a `v*-beta` tag and confirm the release is marked as pre-release

🤖 Generated with [Claude Code](https://claude.com/claude-code)