### PR TITLE
Show a message when a group cannot be accessed

### DIFF
--- a/src/scenes/forum.rb
+++ b/src/scenes/forum.rb
@@ -608,6 +608,8 @@ return result
            forumsmain(g.id) if g.role == 1 or g.role == 2 or g.public
          end
          @grpsel.rows[@grpsel.index][-1]=(g.posts-g.readposts).to_s
+      else
+        alert(p_("Forum", "You cannot access this group."))
       end
     end
   end


### PR DESCRIPTION
When a user tries to open a group they cannot access, Elten now displays a message instead of remaining silent.

Forum thread: https://elten.link/pl/forum/thread/21588