### PR TITLE
Load more user forum posts with Shift+Enter

### DIFF
--- a/src/scenes/forum.rb
+++ b/src/scenes/forum.rb
@@ -3889,7 +3889,9 @@ class Scene_Forum_UserPosts
           open_post
           return
         elsif @more
-          load_older
+          limit = PAGE_SIZE
+          limit = 500 if key_held?(0x10)
+          load_older(limit)
         end
       end
 
@@ -3911,9 +3913,9 @@ class Scene_Forum_UserPosts
     end
   end
 
-  def load_page(before = nil)
+  def load_page(before = nil, limit = PAGE_SIZE)
     page = forum_fetch(nil) do
-      EltenLink::Forum.user_posts(elten_link, user: @user, before: before, limit: PAGE_SIZE)
+      EltenLink::Forum.user_posts(elten_link, user: @user, before: before, limit: limit)
     end
     return false if page.nil?
 
@@ -3923,9 +3925,9 @@ class Scene_Forum_UserPosts
     true
   end
 
-  def load_older
+  def load_older(limit = PAGE_SIZE)
     first_new_index = @posts.length
-    return unless load_page(@next_before)
+    return unless load_page(@next_before, limit)
 
     rebuild_list(first_new_index)
     @list.say_option


### PR DESCRIPTION
Shift+Enter on "Show older" in the user forum posts list now requests up to 500 posts, matching the behavior available in messages. Enter keeps its existing behavior.

The server currently returns at most 100 posts despite the requested limit of 500, so the server-side limit may also need to be adjusted.
