### PR TITLE
more names in the removal confirmations

### DIFF
--- a/src/scenes/blog.rb
+++ b/src/scenes/blog.rb
@@ -182,7 +182,7 @@ end
 @sel.focus
 end
 def categorydelete
-          confirm(p_("Blog", "Are you sure you want to delete category %{c}?")%{ :c => @categories[@sel.index-1].name}) {
+          confirm(p_("Blog", "Are you sure you want to delete category %{category}?")%{ :category => @categories[@sel.index-1].name}) {
             begin
               EltenLink::Blog.delete_category(elten_link, blog: @owner, category_id: @categories[@sel.index-1].id)
             rescue EltenLink::Error
@@ -420,7 +420,7 @@ else
   end
   end
   def postdelete
-    confirm(p_("Blog", "Are you sure you want to delete post %{p}?")%{ :p => @post[@sel.index].name}) {
+    confirm(p_("Blog", "Are you sure you want to delete post %{post}?")%{ :post => @post[@sel.index].name}) {
     begin
     EltenLink::Blog.delete_post(elten_link, blog: @owner, post_id: @post[@sel.index].id)
     rescue EltenLink::Error
@@ -1224,8 +1224,8 @@ if !blog.library
   @sel.focus
   }
 elsif blog.library && (blog.library_user==Session.name)
-  menu.option(p_("Blog", "Delete from Elten library")) {
-  confirm(p_("Blog", "Are you sure you want to delete blog %{b} from Elten library?")%{ :b => blog.name}) {
+  menu.option(p_("Blog", "Delete from Elten library"), nil, :del) {
+  confirm(p_("Blog", "Are you sure you want to delete blog %{blog} from Elten library?")%{ :blog => blog.name}) {
   EltenLink::Blog.library_delete(elten_link, blog: blog.id)
   }
   refresh

--- a/src/scenes/blog.rb
+++ b/src/scenes/blog.rb
@@ -182,7 +182,7 @@ end
 @sel.focus
 end
 def categorydelete
-          confirm(p_("Blog", "Are you sure you want to delete this category?")+"\r\n"+@categories[@sel.index-1].name) {
+          confirm(p_("Blog", "Are you sure you want to delete category %{c}?")%{ :c => @categories[@sel.index-1].name}) {
             begin
               EltenLink::Blog.delete_category(elten_link, blog: @owner, category_id: @categories[@sel.index-1].id)
             rescue EltenLink::Error
@@ -420,7 +420,7 @@ else
   end
   end
   def postdelete
-    confirm(p_("Blog", "Are you sure you want to delete this post?")+"\r\n"+@post[@sel.index].name) {
+    confirm(p_("Blog", "Are you sure you want to delete post %{p}?")%{ :p => @post[@sel.index].name}) {
     begin
     EltenLink::Blog.delete_post(elten_link, blog: @owner, post_id: @post[@sel.index].id)
     rescue EltenLink::Error
@@ -1225,7 +1225,7 @@ if !blog.library
   }
 elsif blog.library && (blog.library_user==Session.name)
   menu.option(p_("Blog", "Delete from Elten library")) {
-  confirm(p_("Blog", "Are you sure you want to delete this blog from Elten library?")) {
+  confirm(p_("Blog", "Are you sure you want to delete blog %{b} from Elten library?")%{ :b => blog.name}) {
   EltenLink::Blog.library_delete(elten_link, blog: blog.id)
   }
   refresh

--- a/src/scenes/contacts.rb
+++ b/src/scenes/contacts.rb
@@ -69,7 +69,7 @@ loop_update
         end
         if key_pressed?(0x2e) and @type==0
           if @contact.size >= 1
-          if confirm(p_("Contacts", "Are you sure you want to delete contact %{c}?")%{ :c => @contact[@sel.index]})
+          if confirm(p_("Contacts", "Are you sure you want to delete contact %{contact}?")%{ :contact => @contact[@sel.index]})
             $scene = Scene_Contacts_Delete.new(@contact[@sel.index],self)
             @sel.disable_item(@sel.index)
 loop_update            

--- a/src/scenes/contacts.rb
+++ b/src/scenes/contacts.rb
@@ -69,7 +69,7 @@ loop_update
         end
         if key_pressed?(0x2e) and @type==0
           if @contact.size >= 1
-          if confirm(p_("Contacts", "Are you sure you want to delete this contact?"))
+          if confirm(p_("Contacts", "Are you sure you want to delete contact %{c}?")%{ :c => @contact[@sel.index]})
             $scene = Scene_Contacts_Delete.new(@contact[@sel.index],self)
             @sel.disable_item(@sel.index)
 loop_update            

--- a/src/scenes/forum.rb
+++ b/src/scenes/forum.rb
@@ -1554,7 +1554,7 @@ def forumtagsedit(forum)
   }
   if tags.size>0
     menu.option(p_("Forum", "Delete tag"), nil, :del) {
-    confirm(p_("Forum", "Are you sure you want to delete tag %{t}?")%{ :t => tags[sel.index][1]}) {
+    confirm(p_("Forum", "Are you sure you want to delete tag %{tag}?")%{ :tag => tags[sel.index][1]}) {
     if forum_attempt(nil) {
       EltenLink::Forum.delete_forum_tag(elten_link, forumid: forum.id, tag_id: tags[sel.index][0])
     }
@@ -1789,7 +1789,7 @@ break
         }
         if @sforums[@frmsel.index].posts == 0
           m.option(p_("Forum", "Delete forum")) {
-            confirm(p_("Forum", "Are you sure you want to delete forum %{n}?")%{ :n => @sforums[@frmsel.index].fullname}) {
+            confirm(p_("Forum", "Are you sure you want to delete forum %{forum}?")%{ :forum => @sforums[@frmsel.index].fullname}) {
               if forum_attempt(nil) {
                 EltenLink::Forum.delete_forum(elten_link, forumid: @sforums[@frmsel.index].id)
               }

--- a/src/scenes/forum.rb
+++ b/src/scenes/forum.rb
@@ -1554,7 +1554,7 @@ def forumtagsedit(forum)
   }
   if tags.size>0
     menu.option(p_("Forum", "Delete tag"), nil, :del) {
-    confirm(p_("Forum", "Are you sure you want to delete this tag?")) {
+    confirm(p_("Forum", "Are you sure you want to delete tag %{t}?")%{ :t => tags[sel.index][1]}) {
     if forum_attempt(nil) {
       EltenLink::Forum.delete_forum_tag(elten_link, forumid: forum.id, tag_id: tags[sel.index][0])
     }
@@ -1789,7 +1789,7 @@ break
         }
         if @sforums[@frmsel.index].posts == 0
           m.option(p_("Forum", "Delete forum")) {
-            confirm(p_("Forum", "Are you sure you want to delete this forum?")) {
+            confirm(p_("Forum", "Are you sure you want to delete forum %{n}?")%{ :n => @sforums[@frmsel.index].fullname}) {
               if forum_attempt(nil) {
                 EltenLink::Forum.delete_forum(elten_link, forumid: @sforums[@frmsel.index].id)
               }

--- a/src/scenes/main.rb
+++ b/src/scenes/main.rb
@@ -487,9 +487,9 @@ qacdown
   menu.option(p_("Main", "Delete"), nil, :del) {
   ac=0
   if @actions[qacindex].key==0 || @actions[qacindex].show==false
-      ac=confirm(p_("Main", "Are you sure you want to delete quick action %{n}?")%{ :n => @actions[qacindex].label}) ? 1 : 0
+      ac=confirm(p_("Main", "Are you sure you want to delete quick action %{action}?")%{ :action => @actions[qacindex].label}) ? 1 : 0
     else
-      ac=selector([_("Cancel"), p_("Main", "Delete"), p_("Main", "Hide this action")], header: p_("Main", "If you delete action %{n}, you will also delete the keyboard shortcut assigned to it. If you want to keep the keyboard shortcut, you can hide this action. You can show or remove hidden actions at any time.")%{ :n => @actions[qacindex].label}, start_index: 0, cancel_index: 0, flags: 1)
+      ac=selector([_("Cancel"), p_("Main", "Delete"), p_("Main", "Hide this action")], header: p_("Main", "If you delete action %{action}, you will also delete the keyboard shortcut assigned to it. If you want to keep the keyboard shortcut, you can hide this action. You can show or remove hidden actions at any time.")%{ :action => @actions[qacindex].label}, start_index: 0, cancel_index: 0, flags: 1)
       end
       if ac==1
           QuickActions.delete(qacindex)

--- a/src/scenes/main.rb
+++ b/src/scenes/main.rb
@@ -487,9 +487,9 @@ qacdown
   menu.option(p_("Main", "Delete"), nil, :del) {
   ac=0
   if @actions[qacindex].key==0 || @actions[qacindex].show==false
-      ac=confirm(p_("Main", "Are you sure you want to delete this quick action?")) ? 1 : 0
+      ac=confirm(p_("Main", "Are you sure you want to delete quick action %{n}?")%{ :n => @actions[qacindex].label}) ? 1 : 0
     else
-      ac=selector([_("Cancel"), p_("Main", "Delete"), p_("Main", "Hide this action")], header: p_("Main", "If you delete this action, you will also delete the keyboard shortcut assigned to it. If you want to keep the keyboard shortcut, you can hide this action. You can show or remove hidden actions at any time."), start_index: 0, cancel_index: 0, flags: 1)
+      ac=selector([_("Cancel"), p_("Main", "Delete"), p_("Main", "Hide this action")], header: p_("Main", "If you delete action %{n}, you will also delete the keyboard shortcut assigned to it. If you want to keep the keyboard shortcut, you can hide this action. You can show or remove hidden actions at any time.")%{ :n => @actions[qacindex].label}, start_index: 0, cancel_index: 0, flags: 1)
       end
       if ac==1
           QuickActions.delete(qacindex)

--- a/src/scenes/soundthemes.rb
+++ b/src/scenes/soundthemes.rb
@@ -53,7 +53,7 @@ stdownload
                         $scene=Scene_Sounds.new(@soundthemes[@sel.index].file)
           }
           menu.option(p_("SoundThemes", "Delete"), nil, :del) {
-                          confirm(p_("SoundThemes", "Are you sure you want to delete soundtheme %{n}?")%{ :n => @soundthemes[@sel.index].name}) {
+                          confirm(p_("SoundThemes", "Are you sure you want to delete sound theme %{soundtheme}?")%{ :soundtheme => @soundthemes[@sel.index].name}) {
                 File.delete(@soundthemes[@sel.index].file)
                 @return=true
                 main

--- a/src/scenes/soundthemes.rb
+++ b/src/scenes/soundthemes.rb
@@ -52,8 +52,8 @@ stdownload
           menu.option(p_("SoundThemes", "Edit"), nil, "e") {
                         $scene=Scene_Sounds.new(@soundthemes[@sel.index].file)
           }
-          menu.option(p_("SoundThemes", "Delete")) {
-                          confirm(p_("SoundThemes", "Are you sure you want to delete this soundtheme?")) {
+          menu.option(p_("SoundThemes", "Delete"), nil, :del) {
+                          confirm(p_("SoundThemes", "Are you sure you want to delete soundtheme %{n}?")%{ :n => @soundthemes[@sel.index].name}) {
                 File.delete(@soundthemes[@sel.index].file)
                 @return=true
                 main


### PR DESCRIPTION
Added a few missing names to the deletion requests, e.g., for quick actions, “for” names in groups, tags, and users in contacts

- **Added soundtheme name to the removal confirmation**
- **The names of deleted posts and blogs are included in the translation template**
- **Added a few missing names to the removal confirmations**
