### PR TITLE
Adapt Opus FEC to measured packet loss

### DIFF
--- a/src/eapi/conferencecore.rb
+++ b/src/eapi/conferencecore.rb
@@ -1403,6 +1403,9 @@ def initialize(nick=nil)
 @chid=0
 @waiting_channel_id=0
 @frame_id=0
+@fec_enabled=false
+@fec_loss=0.0
+@fec_last_update=0.0
 @chat=[]
 if nick==nil
 @username=$name
@@ -2226,7 +2229,7 @@ fs=(5000/@framesize.to_f).to_i
 for t in @transmitters.values
 if t.losses.size>fs
 all+=fs
-losses=t.losses[-fs..-1].sum
+losses+=t.losses[-fs..-1].sum
 end
 end
 return 0 if all==0
@@ -2581,6 +2584,13 @@ end
 end
 end
 def onstatus(latency,sendbytes,receivedbytes,curlost,curpackets,time)
+if @fec_enabled && Time.now.to_f-@fec_last_update>=10.0
+measured_loss=packetloss
+@fec_loss=@fec_loss*0.7+measured_loss*0.3
+target_loss=[[@fec_loss.round, 0].max, 10].min
+@encoder_mutex.synchronize {@encoder.packetloss=target_loss if @encoder!=nil}
+@fec_last_update=Time.now.to_f
+end
 status={}
 status['latency']=latency+@framesize/1000.0
 status['latency']=0 if latency==0
@@ -2630,9 +2640,12 @@ else
 @encoder.vbr=1
 @encoder.cvbr=0
 end
-@encoder.packetloss=10
+@fec_enabled=params['channel']['fec']==true
+@fec_loss=0.0
+@fec_last_update=Time.now.to_f
+@encoder.packetloss=0
 @encoder.prediction_disabled=true if params['channel']['prediction_disabled']==true
-@encoder.inband_fec=true if params['channel']['fec']==true
+@encoder.inband_fec=true if @fec_enabled
 @encoder.bitrate=params['channel']['bitrate']*1000
 @sltime=params['channel']['framesize']/1000.0
 @sltime=0.01 if @sltime<0.01


### PR DESCRIPTION
## What changed

- Replace the hard-coded 10% Opus packet-loss expectation with an adaptive value.
- Sample actual missing conference audio frames every 10 seconds.
- Smooth the measured loss (70% previous value, 30% current sample) and clamp the encoder hint to 0–10%.
- Keep in-band FEC controlled by the existing channel setting.
- Correct packet-loss aggregation across multiple transmitters.

## Why

The encoder was always configured with `OPUS_SET_PACKET_LOSS_PERC(10)` whenever conference audio parameters were applied. With stereo voice at 56 kbps and 40 ms frames, enabling FEC caused continuous audible clipping/crackling even on a connection with no lost audio frames. Disabling FEC removed the artifacts.

The static 10% hint makes Opus reserve bitrate for loss resilience even when the connection is stable. The new behavior starts at 0% and only raises the hint when missing audio frame IDs are actually observed.

The measured loss is receive-side loss used as a practical estimate for the send path; the protocol currently provides no per-listener loss feedback to the sender.

## User impact

Stable connections no longer lose voice quality merely because FEC is enabled. When audio-frame loss is observed, the FEC loss expectation increases gradually instead of remaining permanently fixed at 10%.

## Validation

- Ruby syntax check passed for `src/eapi/conferencecore.rb`.
- Full Windows x64 Release build completed successfully.
- Manual conference test: stereo, 56 kbps, 40 ms frames, FEC enabled.
- Verified the original artifacts disappeared and did not return after more than one minute.
- Diagnostic run showed zero encode errors, zero PCM-size mismatches, no queue buildup, and zero missing audio frames on the stable test connection.
