### PR TITLE
Show channel and participants for incoming calls

### DIFF
--- a/src/ui/calls.rb
+++ b/src/ui/calls.rb
@@ -12,10 +12,28 @@ class CallWindow
       def initialize(id, caller, channel, password)
         @id, @caller, @channel, @password = id, caller, channel, password
         @form = Form.new([
-        @st_caller = Static.new(p_("EAPI_UI", "%{user} is calling you")%{:user=>@caller}),
+        @st_caller = Static.new(call_description),
         @btn_answer = Button.new(p_("EAPI_UI", "Answer")),
         @btn_reject = Button.new(p_("EAPI_UI", "Reject"))
         ])
+      end
+      def call_description
+        description = p_("EAPI_UI", "%{user} is calling you")%{:user=>@caller}
+        Conference.update_channels
+        call_channel = Conference.channels.find { |item| item.id == @channel.to_i }
+        if call_channel != nil && !call_channel.name.start_with?("VoiceCall_")
+          description += ". " + p_("Conference", "Channel") + ": " + call_channel.name
+        end
+        if call_channel != nil
+          users = call_channel.users.map { |user| user.name.to_s }.reject { |name| name.empty? }
+          if users.size > 0
+            description += ". " + p_("Conference", "Channel users") + " (#{users.size}): " + users.join(", ")
+          end
+        end
+        description
+      rescue Exception => e
+        Log.warning("Incoming call channel lookup failed: #{e.class}: #{e.message}")
+        description
       end
       def update
         @form.update


### PR DESCRIPTION
## What changed

- Resolve the incoming call channel from its channel ID.
- Show the channel name for calls to regular conference channels.
- Keep the existing caller-only message for `VoiceCall_` private call channels.
- Show the current participant count and participant names whenever channel details are available.
- Reuse existing translated Conference labels, so no new locale strings are required.

## Why

Incoming call notifications only identified the caller. Users could not tell which conference channel was calling or who was already present before answering.

## Fallback

If channel details cannot be resolved, the existing caller-only notification is shown and answering the call remains unaffected.

## Validation

- Ruby syntax check passed.
- `git diff --check` passed.
- Windows Release build completed successfully.
- Manually tested in the locally built ELTEN client.