### PR TITLE
Warn before creating threads with missing tags

### DIFF
--- a/locale/elten.pot
+++ b/locale/elten.pot
@@ -7936,6 +7936,11 @@ msgctxt "Forum"
 msgid "No tag value"
 msgstr ""
 
+#: src/scenes/forum.rb:2597
+msgctxt "Forum"
+msgid "You haven't selected all tags. Do you want to select the missing tags?"
+msgstr ""
+
 #: src/scenes/forum.rb:2543 src/scenes/forum.rb:2551 src/scenes/forum.rb:3049
 #: src/scenes/forum.rb:3081
 msgctxt "Forum"

--- a/locale/pl-PL/LC_MESSAGES/elten.po
+++ b/locale/pl-PL/LC_MESSAGES/elten.po
@@ -8170,6 +8170,11 @@ msgctxt "Forum"
 msgid "No tag value"
 msgstr "Nie ustawiaj wartości"
 
+#: src/scenes/forum.rb:2597
+msgctxt "Forum"
+msgid "You haven't selected all tags. Do you want to select the missing tags?"
+msgstr "Nie wybrano wszystkich tagów. Czy chcesz uzupełnić brakujące tagi?"
+
 #: src/scenes/forum.rb:2543 src/scenes/forum.rb:2551 src/scenes/forum.rb:3049
 #: src/scenes/forum.rb:3081
 msgctxt "Forum"

--- a/src/scenes/forum.rb
+++ b/src/scenes/forum.rb
@@ -2590,6 +2590,17 @@ form.wait
     form.fields[-3].trigger(:move)
     polls = []
     files = []
+    confirm_missing_tag = lambda {
+      missing_tag_field = current_tag_fields.find { |field| field.index == 0 }
+      return true if missing_tag_field == nil
+      if confirm(p_("Forum", "You haven't selected all tags. Do you want to select the missing tags?"))
+        form.index = form.fields.index(missing_tag_field)
+        form.focus
+        false
+      else
+        true
+      end
+    }
         loop do
       loop_update
       if type==0
@@ -2682,12 +2693,14 @@ form.wait
       end
       if type == 0
         if (key_held?(0x11) and key_pressed?(:key_enter)) or (form.fields[-2]!=nil && form.fields[-2].pressed?)
+          next if !confirm_missing_tag.call
           play_sound("listbox_select")
           text = form.fields[1].text
           break
         end
       else
         if form.fields[-2]!=nil && form.fields[-2].pressed?
+          next if !confirm_missing_tag.call
           break
         end
       end


### PR DESCRIPTION
## What changed

- Check every available forum tag field before creating a new thread.
- Ask whether the user wants to fill missing tags when at least one tag remains unset.
- Move focus to the first missing tag when the user chooses to complete them.
- Allow intentional submission without all tags when the user declines.
- Apply the same behavior to text and audio threads.
- Add the source translation string and Polish translation.

## Why

Threads could be submitted accidentally without tags, or with only some of the forum's tag fields selected. The form gave no warning before submission.

## Validation

- Ruby syntax check passed.
- `git diff --check` passed.
- Windows Release build completed successfully.
- Manually tested with multiple available tags and confirmed the focus moves to the first missing tag.