### PR TITLE
Show post content when changing post position like in mass actions

### DIFF
--- a/src/scenes/forum.rb
+++ b/src/scenes/forum.rb
@@ -3490,7 +3490,7 @@ end
           m.option(p_("Forum", "Change post position")) {
             sels = []
             for post in @posts
-              sels.push((sels.size + 1).to_s + ": " + post.author + ": " + post.date)
+              sels.push((sels.size + 1).to_s + ": " + post.author + ": " + (post.transcription.strip!="" ? post.transcription[0...5000] : post.post[0...5000]) + ": " + post.date)
             end
             sels.push(p_("Forum", "Move to end"))
             dest = selector(sels, header: p_("Forum", "Place post above"), start_index: @form.index, cancel_index: -1)


### PR DESCRIPTION
The post content or transcription is now shown when changing a post's position, as it is in Mass Actions.

Forum thread: https://elten.link/pl/forum/thread/27411