### PR TITLE
Add shortcut to change post position

### DIFF
--- a/src/scenes/forum.rb
+++ b/src/scenes/forum.rb
@@ -3487,7 +3487,7 @@ end
               end
             end
           }
-          m.option(p_("Forum", "Change post position")) {
+          m.option(p_("Forum", "Change post position"), nil, "o") {
             sels = []
             for post in @posts
               sels.push((sels.size + 1).to_s + ": " + post.author + ": " + post.date)


### PR DESCRIPTION
A Ctrl+O shortcut to change a post's position has been added according to the suggestion in the forum thread.

Forum thread: https://elten.link/pl/forum/thread/27412