### PR TITLE
Preview post beginning before deletion confirmation

### DIFF
--- a/src/scenes/forum.rb
+++ b/src/scenes/forum.rb
@@ -3465,7 +3465,9 @@ end
             end
           }
           m.option(p_("Forum", "Delete post"), nil, "-") {
-            confirm(p_("Forum", "Are you sure you want to delete this post?")) do
+            content = post.transcription.strip!="" ? post.transcription : post.post
+            preview = content.lines.first.to_s.strip
+            confirm(p_("Forum", "Are you sure you want to delete this post?")+"\r\n"+post.authorname+":\r\n"+preview) do
               if forum_attempt(nil) {
                 if @posts.size == 1
                   EltenLink::Forum.delete_thread(elten_link, thread_id: @thread)


### PR DESCRIPTION
The deletion confirmation now shows the post author and the first line of the post. For an audio post, the first line of its transcription is shown instead.

Forum thread: https://elten.link/pl/forum/thread/27401