### PR TITLE
Retry channel listing after a stale VoIP connection

### DIFF
--- a/src/eltenlink/voip.rb
+++ b/src/eltenlink/voip.rb
@@ -180,7 +180,12 @@ update if r!=false
 return r!=false && r['status']=='success'
 end
 def list_channels
-cmd=command('list')
+cmd=command('list', {}, notify_failure: false)
+if cmd==false
+thread=@reconnect_thread
+thread.join(CommandTimeout+3) if thread!=nil && thread.alive?
+cmd=command('list') if @connected && !@reconnecting
+end
 return {} if cmd==false
 return cmd['channels']
 end
@@ -790,10 +795,10 @@ log(2, "VoIP command write: #{$!.to_s}")
 return true
 end
 end
-def handle_command_failure(reconnect)
+def handle_command_failure(reconnect, notify: true)
 return if @closing
 if reconnect
-play_sound("right")
+play_sound("right") if notify
 if @reconnecting==false && (@reconnect_thread==nil || !@reconnect_thread.alive?)
 @reconnect_thread = Thread.new{reconnect()}
 end
@@ -829,7 +834,7 @@ return Zstd.decompress(a)
 end
 ans
 end
-def command(cmd, params={}, reconnect: true)
+def command(cmd, params={}, reconnect: true, notify_failure: true)
 @cmd_mutex||=Mutex.new
 begin
 json=nil
@@ -847,9 +852,10 @@ return false if json['status']!='success'
 return json
 rescue Exception
 log(2, "VoIP command #{cmd}: #{$!.to_s}")
-handle_command_failure(reconnect)
+handle_command_failure(reconnect, notify: notify_failure)
 return false
 end
 end
 end
 end
+


### PR DESCRIPTION
## Problem

After the conference connection has been idle for several minutes, the server may close the command socket. Opening Conferences then sends the initial `list` command over that stale socket. The command fails, starts the existing asynchronous reconnect, and immediately returns `false`, so the UI receives an empty channel collection. Opening Conferences a second time works because reconnection has completed by then.

The observed log contains repeated `SSL_write` / `command write failed` errors.

## Change

- Allow command failures to suppress the error sound for a caller-managed retry.
- When the first channel-list request fails, wait for the reconnect thread for at most `CommandTimeout + 3` seconds.
- Retry `list` once if the VoIP connection has recovered.
- Preserve the previous empty-list fallback if reconnection or the retry does not succeed.

Only `src/eltenlink/voip.rb` is changed.

## Validation

- Ruby syntax check passed.
- ELTEN 3.0 Beta 28 compiled successfully.
- A temporary test-only hook closed the active VoIP command socket immediately before the first channel-list request, deterministically reproducing the stale-connection condition.
- With the fix, the channel list appeared automatically on the first visit after a short reconnect delay; it was not necessary to leave Conferences and open it again.
- The temporary fault-injection hook was removed before this commit, and the normal build completed successfully afterward.

The original reporter could not reproduce the intermittent failure locally, so the root-cause diagnosis is based on the supplied SSL error log, the command/reconnect control flow, and the successful forced-disconnection test.