### PR TITLE
Explain membership requirements for invite-only groups

### DIFF
--- a/src/scenes/forum.rb
+++ b/src/scenes/forum.rb
@@ -781,11 +781,14 @@ if (((@sgroups[@grpsel.index - @grpheadindex].role==1 || (@sgroups[@grpsel.index
       }
       s = ""
       s = p_("Forum", "Join") if @sgroups[@grpsel.index - @grpheadindex].role == 0 and @sgroups[@grpsel.index - @grpheadindex].open and @sgroups[@grpsel.index - @grpheadindex].public
+      s = p_("Forum", "Join") if @sgroups[@grpsel.index - @grpheadindex].role == 0 and !@sgroups[@grpsel.index - @grpheadindex].open and !@sgroups[@grpsel.index - @grpheadindex].public
       s = p_("Forum", "Accept invitation") if @sgroups[@grpsel.index - @grpheadindex].role == 5
       s = p_("Forum", "Ask to be enrolled in this group") if @sgroups[@grpsel.index - @grpheadindex].role == 0 && ((@sgroups[@grpsel.index - @grpheadindex].public && !@sgroups[@grpsel.index - @grpheadindex].open) || (@sgroups[@grpsel.index - @grpheadindex].open && !@sgroups[@grpsel.index - @grpheadindex].public))
       if s != ""
         menu.option(s, nil, "j") {
-        if canjoin(@sgroups[@grpsel.index - @grpheadindex])
+        if @sgroups[@grpsel.index - @grpheadindex].role == 0 && !@sgroups[@grpsel.index - @grpheadindex].open && !@sgroups[@grpsel.index - @grpheadindex].public
+          alert(p_("Forum", "closed (only invited users can join)"))
+        elsif canjoin(@sgroups[@grpsel.index - @grpheadindex])
           if @sgroups[@grpsel.index - @grpheadindex].role == 0 && ((@sgroups[@grpsel.index - @grpheadindex].public && !@sgroups[@grpsel.index - @grpheadindex].open) || (@sgroups[@grpsel.index - @grpheadindex].open && !@sgroups[@grpsel.index - @grpheadindex].public))
             s = p_("Forum", "Do you wish to ask to be enrolled in %{groupname}")
           else


### PR DESCRIPTION
## Problem

For a closed, invite-only forum group, users who are not members currently see neither **Join** nor **Ask to be enrolled** in the context menu. Although this matches the group's access policy, the missing action looks like a UI bug and gives no explanation of how membership works.

## Change

- Show the existing **Join** action for non-members of closed groups.
- When it is selected, display the existing localized message that the group is closed and only invited users can join.
- Do not call the membership API and do not create a join request.

The behavior for open groups, moderated groups, and pending invitations is unchanged. The change reuses an existing translation, so only `src/scenes/forum.rb` is modified.

## Validation

- Ruby syntax check passed.
- ELTEN 3.0 Beta 28 compiled successfully.
- Manually tested with a closed group: **Join** appeared in the context menu and selecting it displayed the invitation-only explanation.
- Confirmed that no membership request is sent for this path.