### PR TITLE
Hide post type selection in closed threads

### DIFF
--- a/src/scenes/forum.rb
+++ b/src/scenes/forum.rb
@@ -2891,9 +2891,8 @@ return $scene=Scene_Main.new if @form==nil
       @form.update
       if @closed_thread_reply_button != nil && @closed_thread_reply_button.pressed?
         @noteditable = false
-        refresh
         @form.index = @postscount * 3 + ((@type == 2) ? 0 : 1)
-        @form.focus
+        refresh
         next
       end
       if @noteditable == false
@@ -3067,7 +3066,7 @@ end
     @type = @threadclass.forum.type
     @posttype=0
     @posttype=1 if @type==1
-    if @type==2
+    if @type==2 && @noteditable==false
     sel=ListBox.new([p_("Forum", "Text post"), p_("Forum", "Audio post")], header: p_("Forum", "Post type"))
     sel.on(:move) {|i|
     if @noteditable==false


### PR DESCRIPTION
The unnecessary post type selector is now hidden when a thread cannot be edited. In closed threads, moderators first use the existing button for writing despite the closure and are then taken directly to the post type selector without focusing the reply field first.

Forum thread: https://elten.link/pl/forum/thread/27473