### PR TITLE
Unify context menu layout in the menu bar

### DIFF
--- a/src/eapi/mainmenu.rb
+++ b/src/eapi/mainmenu.rb
@@ -28,14 +28,24 @@ module GlobalMenu
     style=:menubar if defaults
     @menu = Menu.new("",style)
     if $activecontrols!=nil
-        for c in $activecontrols||[]
+      active_controls = $activecontrols || []
+      for c in active_controls
       if !c.menu_enabled?
         return
         end
+      end
       if defaults != :defaults && (Configuration.contextmenubar==true || defaults==false || force_context)
-        c.context(@menu, defaults)
-    end
-  end
+        if defaults
+          context_controls = active_controls.select { |control| control.hascontext }
+          if context_controls.size > 0
+            @menu.submenu(_("Context menu")) do |context_menu|
+              context_controls.each { |control| control.context(context_menu, false) }
+            end
+          end
+        else
+          active_controls.each { |control| control.context(@menu, false) }
+        end
+      end
   end
   if defaults==true && !$scene.is_a?(Scene_Main) && (Session.logged? || $preinitialized==true)
     @menu.submenu(p_("MainMenu", "Quick &actions")) {|m|


### PR DESCRIPTION
## Problem

When the “Display context menu in menu bar” option is enabled, opening the menu bar with Left Alt presents context actions differently from Shift+F10 or the context-menu key. Controls contribute separate nested menus, and edit boxes produce a verbose menu name based on the focused field.

## Root cause

The global menu passed the menu-bar nesting mode to every active control. The regular context-menu path passes the flat mode instead, so the two invocation methods assembled the same actions with different structures.

## Changes

- collect active controls before adding contextual actions;
- keep the existing menu-disabled guard;
- add one Context menu entry to the menu bar;
- populate that entry using the same flat control layout as Shift+F10;
- keep direct context-menu invocation unchanged.

## Validation

- Ruby syntax check passed for src/eapi/mainmenu.rb;
- the Windows x64 Release build completed successfully;
- manually tested both Left Alt and Shift+F10/context-menu-key invocation;
- confirmed that the menu bar contains one Context menu entry rather than placing every context action directly on the top level.