### PR TITLE
Accept translator dialog with Enter key

### DIFF
--- a/src/eapi/external.rb
+++ b/src/eapi/external.rb
@@ -62,18 +62,17 @@ text=text[0..5000]
  submit=Button.new(p_("EAPI_External", "Translate"))
  cancel=Button.new(_("Cancel"))
  form=Form.new([from,to,submit,cancel])
-loop do
-  loop_update
-  form.update
-  if key_pressed?(:key_escape) or ((key_pressed?(:key_space) or key_pressed?(:key_enter)) and form.index==3)
-    dialog_close
-    loop_update
-    return -1
-  end
-  if (key_pressed?(:key_space) or key_pressed?(:key_enter)) and form.index == 2
-        break
-    end
-  end
+ form.accept_button=submit
+ form.cancel_button=cancel
+ result=nil
+ submit.on(:press) { result=:ok; form.resume }
+ cancel.on(:press) { result=:cancel; form.resume }
+ form.wait
+ if result!=:ok
+   dialog_close
+   loop_update
+   return -1
+ end
   lfrom=0
   if from.index==0
       lfrom=0


### PR DESCRIPTION
## What changed

- Replace the manual key-handling loop in the translator dialog with the
  form's built-in `accept_button` / `cancel_button` mechanism.
- Enter on any field (language lists or buttons) now confirms and runs
  the translation; Escape cancels.

## Why

The translator dialog (Ctrl+Shift+T) only listened for Enter/Space on the
button at form index 2, so pressing Enter while focused on the source or
destination language list did nothing — the user had to Tab all the way to
the OK button to confirm. Other dialogs (e.g. program settings) already use
the standard `accept_button` pattern, where Enter confirms from any field.

## User impact

Pressing Enter from any field in the translator dialog immediately starts
the translation, matching the behavior users expect from other Elten dialogs.
Reported in "Szybsza opcja Tłumacz" (by Postukujący).

## Validation

- Ruby syntax check passed for `src/eapi/external.rb`.
- Tested locally via source run (`bundle exec ruby elten.rb`): Enter confirms
  from every field, Escape cancels.
