### PR TITLE
Allow pinning received mentions to quick actions

### DIFF
--- a/src/scenes/forum.rb
+++ b/src/scenes/forum.rb
@@ -83,6 +83,10 @@ class Scene_Forum
     { "type" => "forum", "id" => id.to_i }
   end
 
+  def self.mentions_target
+    { "type" => "mentions" }
+  end
+
   def initialize(pre = nil, preparam = nil, cat = 0, query = "", tc=nil, tag=nil)
     @pre = pre
     @preparam = preparam
@@ -96,6 +100,10 @@ class Scene_Forum
 
   def forum_target?(target)
     target.is_a?(Hash) && target["type"].to_s == "forum" && target["id"].to_i.positive?
+  end
+
+  def mentions_target?(target)
+    target.is_a?(Hash) && target["type"].to_s == "mentions"
   end
 
   def forum_target_id(target)
@@ -201,7 +209,9 @@ class Scene_Forum
     getcache
     return if $scene != self
     if @pre == nil
-      if forum_target?(@preparam)
+      if mentions_target?(@preparam)
+        return threadsmain(-11)
+      elsif forum_target?(@preparam)
         return threadsmain(forum_target_id(@preparam))
       elsif @preparam.is_a?(Integer)
 return forumsmain(@preparam)
@@ -644,6 +654,15 @@ return result
     menu.option(p_("Forum", "Open")) {
       groupopen(@grpsel.index, type)
     }
+    if @grpsel.index == @grpheadindex + @sgroups.size + 9
+      menu.option(p_("Forum", "Add received mentions to quick actions"), nil, "q") {
+        if QuickActions.create(Scene_Forum, p_("Forum", "Received mentions"), [nil, Scene_Forum.mentions_target])
+          alert(p_("Forum", "Received mentions added to quick actions"), false)
+        else
+          alert(_("Error"))
+        end
+      }
+    end
     if @grpsel.index >= @grpheadindex and @grpsel.index < @grpheadindex + @sgroups.size
       g = @sgroups[@grpsel.index - @grpheadindex]
       menu.option(p_("Forum", "Show all threads"), nil, :shift_enter) {


### PR DESCRIPTION
## What changed

- Add a `mentions_target` descriptor (and `mentions_target?` check) so the "Received mentions" view can be referenced as a quick-action target.
- Handle that target in `Scene_Forum#main` so opening the quick action shows the received mentions list.
- Add a context-menu option on the "Received mentions" row in the forum group list to pin it to quick actions, mirroring how groups and forums are pinned.

## Why

The forum group list already lets users pin groups and forums to quick actions, but the "Received mentions" entry could only be opened, not pinned. Users who frequently check their mentions had no way to keep them one keystroke away from the main window like their pinned groups.

## User impact

Received mentions can now be pinned to quick actions from the forum group list context menu, exactly like groups and forums. The pinned entry opens the received mentions list and survives a restart (stored in the serialized quick-action params).

## Validation

- Ruby syntax check passed for `src/scenes/forum.rb`.
- Tested locally via source run (`bundle exec ruby elten.rb`): pinned "Received mentions" from the group list context menu, confirmed it appears in the main window quick actions and opens the mentions list.

Note: the two new strings ("Add received mentions to quick actions", "Received mentions added to quick actions") are English-only for now; `p_` falls back to the source string, so translations can be added later.
