### PR TITLE
Open birthday notifications in user menu

### DIFF
--- a/src/eapi/notificationgroups.rb
+++ b/src/eapi/notificationgroups.rb
@@ -402,11 +402,20 @@ module NotificationGroups
     when "friend"
       Proc.new { insert_scene(Scene_Users_AddedMeToContacts.new(true), true) }
     when "birthday"
-      Proc.new { insert_scene(Scene_Contacts.new(1), true) }
+      Proc.new { open_birthday(payload) }
     when "groupinvitation"
       Proc.new { insert_scene(Scene_Forum.new(nil, nil, 4), true) }
     else
       nil
+    end
+  end
+
+  def open_birthday(payload)
+    user = payload["user"].to_s
+    if user.empty?
+      insert_scene(Scene_Contacts.new(1), true)
+    else
+      usermenu(user)
     end
   end
 


### PR DESCRIPTION
## What changed

- Birthday notifications now open the standard user menu for the person named in the notification payload.
- Closing the user menu with Escape returns directly to the notifications scene, whose existing flow marks the opened notification as read and refreshes the list.
- Older birthday notifications without a `user` value retain the previous birthday-list fallback.

## Why

Opening a birthday notification previously displayed an untitled list of birthdays for the day. With one birthday in particular, it was unclear what screen had opened, and returning from it felt disconnected from the notification that initiated the action. The user menu provides the relevant actions directly, including sending a private message and starting a call when available.

## Validation

- `ruby -c src/eapi/notificationgroups.rb`
- `git diff --check`
- Windows x64 Release build completed successfully.
- Manually tested with a temporary synthetic birthday notification: opening it displayed the expected user menu, and Escape returned to notifications. The synthetic notification was removed before committing.
