### PR TITLE
Open user feed with Tab from online and contacts lists

### DIFF
--- a/src/scenes/contacts.rb
+++ b/src/scenes/contacts.rb
@@ -79,6 +79,9 @@ loop_update
         if key_pressed?(:key_enter) and @contact.size > 0
                     usermenu(@contact[@sel.index],false)
           end
+        if key_pressed?(:key_tab) and @contact.size > 0
+                    insert_scene(Scene_FeedViewer.new(@contact[@sel.index]))
+          end
         end
             
 

--- a/src/scenes/feedviewer.rb
+++ b/src/scenes/feedviewer.rb
@@ -43,7 +43,7 @@ ind=@ind if @ind!=-1
 loop do
   loop_update
   @sel.update
-  break if key_pressed?(:key_escape) or (@first!=true && @sel.collapsed?)
+  break if key_pressed?(:key_escape) or key_pressed?(:key_tab) or (@first!=true && @sel.collapsed?)
   break if $scene!=self
   if @sel.expanded? && @feeds.size>0 && @feeds[@sel.index].responses>0 && !responses_shown?(@feeds[@sel.index])
     feed=@feeds[@sel.index]

--- a/src/scenes/online.rb
+++ b/src/scenes/online.rb
@@ -31,6 +31,9 @@ loop_update
       if key_pressed?(:key_enter)
                 usermenu(@onl[@sel.index],false)
         end
+      if key_pressed?(:key_tab) and @onl.size > 0
+        insert_scene(Scene_FeedViewer.new(@onl[@sel.index]))
+        end
       break if $scene != self
       end
     end


### PR DESCRIPTION
## What changed

Add Tab as a shortcut to open the highlighted user's feed from the "Who is online?" and "My contacts" lists, mirroring the "Show feed" context-menu action. Pressing Tab again (with or without Shift) closes the feed and returns to the originating list, so the two views form a consistent Tab cycle.

- `src/scenes/online.rb`: Tab on a user opens their feed.
- `src/scenes/contacts.rb`: Tab on a contact opens their feed.
- `src/scenes/feedviewer.rb`: Tab / Shift+Tab leaves the feed and returns to the list it was opened from.

## Why

Reaching a user's feed previously required opening the context menu and selecting "Show feed". A single Tab keystroke is faster and matches the quick-actions navigation pattern on the main screen, where Tab cycles between sections.

## User impact

On "Who is online?" and "My contacts", highlight a user and press Tab to jump straight to their feed. Press Tab again to cycle back to the list. Enter (context menu), Escape and all other keys behave exactly as before.

## Validation

- `ruby -c` on all three changed files: Syntax OK.
- Manually tested from source (`bundle exec ruby elten.rb`): Tab opens the feed and cycles back to the list on both the online and contacts screens; Escape still returns to the list.
