### PR TITLE
Fix keyboard navigation in Invisible Interface text dialogs

### DIFF
--- a/src/platforms/windows/invisibleinterface/nativedialogs.rb
+++ b/src/platforms/windows/invisibleinterface/nativedialogs.rb
@@ -19,6 +19,7 @@ module EltenAPI
       ES_LEFT = 0x00000000
       ES_MULTILINE = 0x0004
       ES_AUTOVSCROLL = 0x0040
+      ES_WANTRETURN = 0x1000
       BS_DEFPUSHBUTTON = 0x00000001
       SW_MAXIMIZE = 3
       SWP_NOSIZE = 0x0001
@@ -38,8 +39,10 @@ module EltenAPI
       EN_CHANGE = 0x0300
       VK_ESCAPE = 0x1B
       VK_RETURN = 0x0D
-      VK_TAB = 0x09
+      VK_CONTROL = 0x11
+      VK_MENU = 0x12
       VK_SHIFT = 0x10
+      VK_A = 0x41
       DLGC_WANTARROWS = 0x0001
       DLGC_WANTTAB = 0x0002
       DLGC_WANTALLKEYS = 0x0004
@@ -49,6 +52,8 @@ module EltenAPI
       EM_SETSEL = 0x00B1
       EM_SETLIMITTEXT = 0x00C5
       DELETE_WORD_CHARACTER = 0x7F
+      IDOK = 1
+      IDCANCEL = 2
       IDC_ARROW = 32512
       IDI_APPLICATION = 32512
       COLOR_WINDOW = 5
@@ -145,7 +150,6 @@ module EltenAPI
           @get_window_text = Fiddle::Function.new(user32["GetWindowTextW"], [PTR, Fiddle::TYPE_VOIDP, Fiddle::TYPE_INT], Fiddle::TYPE_INT)
           @get_window_text_length = Fiddle::Function.new(user32["GetWindowTextLengthW"], [PTR], Fiddle::TYPE_INT)
           @get_key_state = Fiddle::Function.new(user32["GetKeyState"], [Fiddle::TYPE_INT], Fiddle::TYPE_SHORT)
-          @get_next_tab_item = Fiddle::Function.new(user32["GetNextDlgTabItem"], [PTR, PTR, Fiddle::TYPE_INT], PTR)
           @call_window_proc = Fiddle::Function.new(user32["CallWindowProcW"], [PTR, PTR, Fiddle::TYPE_INT, PTR, PTR], PTR)
           @def_window_proc = Fiddle::Function.new(user32["DefWindowProcW"], [PTR, Fiddle::TYPE_INT, PTR, PTR], PTR)
           @load_cursor = Fiddle::Function.new(user32["LoadCursorW"], [PTR, PTR], PTR)
@@ -170,7 +174,7 @@ module EltenAPI
           :set_active_window, :set_focus, :set_window_text, :post_message, :post_thread_message, :get_foreground_window, :get_window_thread_process_id, :attach_thread_input,
           :get_current_thread_id, :get_message, :translate_message, :dispatch_message, :is_dialog_message,
           :post_quit_message, :send_message, :get_window_text, :get_window_text_length, :get_key_state,
-          :get_next_tab_item, :call_window_proc, :def_window_proc, :set_window_long_ptr, :window_proc, :edit_proc,
+          :call_window_proc, :def_window_proc, :set_window_long_ptr, :window_proc, :edit_proc,
           :get_open_file_name
 
         def last_error
@@ -374,7 +378,12 @@ module EltenAPI
         def edit_proc(hwnd, message, wparam, lparam)
           case message
           when WM_GETDLGCODE
-            DLGC_WANTCHARS | DLGC_HASSETSEL | DLGC_WANTALLKEYS | DLGC_WANTARROWS | DLGC_WANTTAB
+            code = call_previous(hwnd, message, wparam, lparam).to_i & ~(DLGC_WANTTAB | DLGC_WANTALLKEYS)
+            if wparam.to_i == VK_RETURN && (NativeDialogs.api.get_key_state.call(VK_SHIFT) & 0x8000) != 0
+              code | DLGC_WANTALLKEYS
+            else
+              code
+            end
           when WM_SETFOCUS
             @focus_hwnd = hwnd.to_i
             call_previous(hwnd, message, wparam, lparam)
@@ -390,10 +399,8 @@ module EltenAPI
             if key == VK_ESCAPE
               close(false)
               return 0
-            elsif key == VK_TAB
-              reverse = (NativeDialogs.api.get_key_state.call(VK_SHIFT) & 0x8000) != 0
-              next_hwnd = NativeDialogs.api.get_next_tab_item.call(@hwnd, hwnd, reverse ? 1 : 0)
-              NativeDialogs.api.set_focus.call(next_hwnd) if next_hwnd.to_i != 0
+            elsif key == VK_A && (NativeDialogs.api.get_key_state.call(VK_CONTROL) & 0x8000) != 0 && (NativeDialogs.api.get_key_state.call(VK_MENU) & 0x8000) == 0
+              NativeDialogs.api.send_message.call(hwnd, EM_SETSEL, 0, -1)
               return 0
             elsif key == VK_RETURN && (NativeDialogs.api.get_key_state.call(VK_SHIFT) & 0x8000) == 0
               submit
@@ -443,7 +450,7 @@ module EltenAPI
             edit_height = field[:multiline] ? (@fields.size == 1 ? 350 : 210) : 28
             label = api.create_window.call(0, NativeDialogs.wide("STATIC"), NativeDialogs.wide(field[:label]), WS_CHILD | WS_VISIBLE | SS_LEFT, 20, y, 190, label_height, @hwnd, 0, api.get_module_handle.call(nil), nil)
             edit_style = WS_CHILD | WS_VISIBLE | WS_TABSTOP | ES_LEFT
-            edit_style |= ES_MULTILINE | ES_AUTOVSCROLL | WS_VSCROLL if field[:multiline]
+            edit_style |= ES_MULTILINE | ES_AUTOVSCROLL | ES_WANTRETURN | WS_VSCROLL if field[:multiline]
             edit = api.create_window.call(0, NativeDialogs.wide("EDIT"), NativeDialogs.wide(field[:value].to_s), edit_style, 220, y, 400, edit_height, @hwnd, 0, api.get_module_handle.call(nil), nil)
             @hwnds.push(label.to_i, edit.to_i)
             @field_hwnds[field[:id]] = edit
@@ -457,8 +464,8 @@ module EltenAPI
             @edit_previous[edit.to_i] = previous if previous.to_i != 0
             y += edit_height + 18
           end
-          @send_button = api.create_window.call(0, NativeDialogs.wide("BUTTON"), NativeDialogs.wide(@send_label), WS_CHILD | WS_VISIBLE | WS_TABSTOP | BS_DEFPUSHBUTTON, 20, 410, 300, 42, @hwnd, 0, api.get_module_handle.call(nil), nil)
-          @cancel_button = api.create_window.call(0, NativeDialogs.wide("BUTTON"), NativeDialogs.wide(@cancel_label), WS_CHILD | WS_VISIBLE | WS_TABSTOP, 320, 410, 300, 42, @hwnd, 0, api.get_module_handle.call(nil), nil)
+          @send_button = api.create_window.call(0, NativeDialogs.wide("BUTTON"), NativeDialogs.wide(@send_label), WS_CHILD | WS_VISIBLE | WS_TABSTOP | BS_DEFPUSHBUTTON, 20, 410, 300, 42, @hwnd, IDOK, api.get_module_handle.call(nil), nil)
+          @cancel_button = api.create_window.call(0, NativeDialogs.wide("BUTTON"), NativeDialogs.wide(@cancel_label), WS_CHILD | WS_VISIBLE | WS_TABSTOP, 320, 410, 300, 42, @hwnd, IDCANCEL, api.get_module_handle.call(nil), nil)
           @hwnds.push(@send_button.to_i, @cancel_button.to_i)
           @focus_hwnd = @fields.any? { |field| field[:value].to_s != "" } ? @field_hwnds[@fields.last[:id]] : first_edit
           api.show_window.call(@hwnd, SW_MAXIMIZE)

--- a/src/platforms/windows/invisibleinterface/service.rb
+++ b/src/platforms/windows/invisibleinterface/service.rb
@@ -163,6 +163,7 @@ module EltenAPI
         @message_id_pending = false
         @message_request_pending = false
         @message_request_token = 0
+        @message_submit_token = 0
         @message_lasttext = nil
         @message_lastsubject = nil
         @message_lastrecipient = nil
@@ -193,7 +194,9 @@ module EltenAPI
         when :message_result
           handle_message_result(job[1], job[2], job[3])
         when :message_submit
-          submit_message(job[1])
+          start_message_submit(job[1])
+        when :message_submit_result
+          finish_message_submit(job[1], job[2], job[3])
         when :feed_submit
           submit_feed(job[1], job[2])
         when :chat_submit
@@ -240,6 +243,7 @@ module EltenAPI
 
       def reset_session
         @message_request_token = @message_request_token.to_i + 1
+        @message_submit_token = @message_submit_token.to_i + 1
         @message_request_pending = false
         @message_id = 0
         @message_id_pending = false
@@ -717,17 +721,33 @@ module EltenAPI
         play_sound("signal")
       end
 
-      def submit_message(values)
-        EltenLink::Messages.send_text(
-          elten_link,
-          to: values[:recipient].to_s,
-          subject: values[:subject].to_s,
-          text: values[:text].to_s
-        )
+      def start_message_submit(values)
+        token = @message_submit_token.to_i
         play_sound("messages_update")
-      rescue Exception => e
-        Log.error("InvisibleInterface message submit: #{e.class}: #{e.message}")
-        open_message_dialog(values[:recipient], values[:subject], values[:text], p_("Messages", "Failed to send message"))
+        Thread.new do
+          Thread.current.report_on_exception = false
+          error = nil
+          begin
+            EltenLink::Messages.send_text(
+              elten_link,
+              to: values[:recipient].to_s,
+              subject: values[:subject].to_s,
+              text: values[:text].to_s
+            )
+          rescue Exception => e
+            error = e
+          ensure
+            @jobs << [:message_submit_result, token, values, error]
+          end
+        end
+      end
+
+      def finish_message_submit(token, values, error)
+        return if token.to_i != @message_submit_token.to_i
+        if error != nil
+          Log.error("InvisibleInterface message submit: #{error.class}: #{error.message}")
+          open_message_dialog(values[:recipient], values[:subject], values[:text], p_("Messages", "Failed to send message"))
+        end
       end
 
       def submit_feed(text, response=0)


### PR DESCRIPTION
## What changed

- use standard Windows dialog navigation for Tab and Shift+Tab instead of custom button and focus handling
- assign standard `IDOK` and `IDCANCEL` identifiers to Send and Cancel
- preserve Ctrl+A selection in native edit fields without treating AltGr+A (`ą`) as Ctrl+A
- let multiline edit fields handle Shift+Enter while ordinary Enter continues to submit
- keep the existing Ctrl+Backspace word-deletion behavior
- send private messages in the background so a server response cannot block Invisible Interface hotkeys or the next message form
- play the message update sound immediately after accepting a message for sending
- reopen the form with its original contents if background sending fails

## Why

After navigating away from the message text and returning to Send, Enter could stop activating the button while Space still worked. Tab could wrap inconsistently or be inserted into the message text. Earlier attempts to handle every key through custom control procedures also interfered with Invisible Interface hotkeys after sending.

The root cause was a conflict between custom control-level keyboard handling and the standard Windows dialog manager. The dialog manager also treated Shift+Enter as activation of the default Send button unless the multiline edit explicitly requested that key. Synchronous network submission additionally kept the Invisible Interface worker occupied while waiting for the server.

## User impact

- Tab and Shift+Tab navigate the form using normal Windows dialog behavior
- Enter and Space activate buttons consistently after repeated focus changes
- Shift+Enter inserts a new line in message text
- Tab is not inserted into message text
- Polish characters entered with AltGr continue to work
- another message can be composed immediately while the previous one finishes sending
- the user receives immediate audible feedback after submitting

## Validation

- manually tested repeated navigation between message text, Send, and Cancel
- manually tested Enter, Space, Shift+Enter, Ctrl+A, AltGr+A (`ą`), and continued Invisible Interface operation after sending
- manually tested sending another message immediately after the first
- verified the final diff with `git diff --check`
- completed a full Windows x64 build against current `main` / ELTEN 3.0 BETA 29 using Visual Studio Build Tools 2026
