### PR TITLE
Focus attachments list when composing via the attach button

### DIFF
--- a/src/scenes/messages.rb
+++ b/src/scenes/messages.rb
@@ -727,7 +727,7 @@ elsif @form_messages.fields[3].text!="" and @form_messages.fields[4]==nil
 load_messages(@messages_user, @messages_subject, @messages_sp, @messages_limit, true)
       end
 if (key_pressed?(:key_enter) or key_pressed?(:key_space)) and @form_messages.index==5
-    $scene = Scene_Messages_New.new(@messages_user,"RE: " + (@messages_subject||"").sub("RE: ",""),@form_messages.fields[3],export)  
+    $scene = Scene_Messages_New.new(@messages_user,"RE: " + (@messages_subject||"").sub("RE: ",""),@form_messages.fields[3],export,5)  
   end
           end
       end
@@ -885,11 +885,12 @@ def audiolimit
     end
      
      class Scene_Messages_New
-       def initialize(receiver="",subject="",text="",scene=false)
+       def initialize(receiver="",subject="",text="",scene=false,focus_field=nil)
          @receiver = receiver
          @subject = subject
          @text = text
          @scene = scene
+         @focus_field = focus_field
          end
        def main
          receiver=@receiver
@@ -981,6 +982,7 @@ def audiolimit
                       ind=0
            ind=1 if receiver!=""
            ind=2 if receiver!="" and subject!=""
+           ind=@focus_field if @focus_field!=nil && @fields[@focus_field]!=nil
            @form = Form.new(@fields,index: ind)
 @attachments=[]
 @polls=[]


### PR DESCRIPTION
## What changed

When composing a reply from within a conversation, pressing Enter (or Space) on the "Attach a file or poll" button now opens the compose window with focus on the Attachments list, instead of landing in the "Your reply" message body.

- `src/scenes/messages.rb`: `Scene_Messages_New#initialize` gains an optional `focus_field` argument (default `nil`); the starting form index honours it when the field exists. The attach-button caller passes the Attachments field index.

## Why

Reaching the attachments list previously required an extra Tab from the message body every time. Since the button is explicitly about attaching, focusing the Attachments list directly matches the user's intent.

## User impact

In a conversation, Enter on "Attach a file or poll" lands directly on the Attachments list. All other ways of opening the compose window (new message, reply, forward, etc.) are unchanged — `focus_field` defaults to `nil`.

## Validation

- `ruby -c src/scenes/messages.rb`: Syntax OK.
- Manually tested from source: focus now starts on the Attachments list when opening compose via the attach button; other entry points behave as before.
