### PR TITLE
Fix cursor position when replying to feed posts

### DIFF
--- a/src/eapi/eltensrv/feeds.rb
+++ b/src/eapi/eltensrv/feeds.rb
@@ -47,6 +47,7 @@ module EltenAPI
       text<<" " if text!=""
       message_header=p_("FeedViewer", "Message")
       edit=EditBox.new(message_header, type: 0, text: text, max_length: message_max_length)
+      edit.index=edit.check=text.length
       update_message_header=lambda do
         count=edit.text.to_s.chrsize
         edit.header = if count>0


### PR DESCRIPTION
As before, the cursor is now placed at the end of the initial text when replying to a feed post. This prevents users from accidentally overwriting or deleting the mentions added to the reply.

Forum thread: https://elten.link/pl/forum/thread/27593