### PR TITLE
Fix crash and needless refresh when bouncing off inaccessible group

### DIFF
--- a/src/scenes/forum.rb
+++ b/src/scenes/forum.rb
@@ -297,7 +297,8 @@ end
       break if $scene!=self
       if (key_pressed?(:key_enter) or key_pressed?(:key_right) and !key_held?(0x10))
         groupopen(@grpsel.index, type, false)
-break
+        break if $scene != self
+        @grpsel.focus
       end
       break if $scene!=self
     end
@@ -1459,6 +1460,11 @@ chk_transcriptions.checked=false if !requires_premiumpackage("courier")
   def forumsmain(group = -1)
     group = @group if group == -1
     group = 0 if group == -1
+    if group.nil?
+      forum = @forums.find { |f| f.id == @frmsetid } if @frmsetid != nil && @forums != nil
+      return groupsmain if forum.nil?
+      group = forum.group.id
+    end
     @group = group
     forumsload(group)
     loop do


### PR DESCRIPTION
## What changed

Fixes two related issues when bouncing off a group the user cannot access:

1. **`groupsmain` no longer forces a full refresh after a failed open.** Opening a
   closed group previously broke out of the groups loop unconditionally, ending the
   scene and triggering a full `getcache` server round-trip on re-entry. The break is
   now conditional on the scene actually changing (`break if $scene != self`), and the
   list is re-focused, so bouncing off a closed group keeps the user in place with no
   needless request.
2. **`forumsmain` no longer crashes on a nil group.** `groupopen` sets `@group = nil`;
   after bouncing off a closed group it stayed nil, so a later back-navigation called
   `forumsmain` with no argument, passing `nil` to `forumsload`, which crashed on
   `nil >= 0` (`undefined method '>=' for nil`). `forumsmain` now recovers the real
   group from `@frmsetid` when available, or falls back to the groups list.

## Why

Reported on the forum: opening a closed group showed "You cannot access this group",
and a subsequent quick left-arrow first threw the user onto an unrelated previously-read
thread list, then crashed with:

```
src/scenes/forum.rb:1485:in 'Scene_Forum#forumsload': undefined method '>=' for nil (NoMethodError)
```

Problem 2 is the crash itself; problem 1 both loads the server unnecessarily and can
mask errors like this one (without the redundant refresh the crash could not occur).

## User impact

Bouncing off an inaccessible group is now stable: no crash, no stray thread list, and
no extra server request. Normal group navigation is unchanged.

## Validation

- `ruby -c src/scenes/forum.rb` -> Syntax OK.
- Ad-hoc logic harness reproducing the exact code path: confirmed old `forumsload(nil)`
  raises `undefined method '>='`, the new guard recovers the group from `@frmsetid` or
  falls back to the groups list, and normal values (-5, 0, positive ids) pass through
  unchanged.
- Manually verified in a local build from source: opening a closed group and navigating
  back no longer crashes.
