### PR TITLE
Confirm before discarding editors with unsaved text

### DIFF
--- a/src/scenes/blog.rb
+++ b/src/scenes/blog.rb
@@ -2068,8 +2068,12 @@ end
 }
 }
 changed=false
+edt_title.on(:delete) {changed=true}
+edt_title.on(:insert) {changed=true}
 edt_post.on(:delete) {changed=true}
 edt_post.on(:insert) {changed=true}
+edt_excerpt.on(:delete) {changed=true}
+edt_excerpt.on(:insert) {changed=true}
 for i in 0...@categories.size
   lst_categories.selected[i] = true if @categories[i].id == @category
 end

--- a/src/scenes/calendar.rb
+++ b/src/scenes/calendar.rb
@@ -90,12 +90,14 @@ module CalendarSceneHelpers
     apply_event_range_visibility(form, lst_range.index, hour_fields, custom_fields)
     accepted = false
     times = nil
+    init_name = edt_name.text.to_s
+    init_desc = edt_description.text.to_s
     dialog_open
     loop do
       loop_update
       form.update
       if key_pressed?(:key_escape) || ((key_pressed?(:key_enter) || key_pressed?(:key_space)) && form.index == 11)
-        break
+        break if (edt_name.text.to_s == init_name && edt_description.text.to_s == init_desc) || confirm(p_("Calendar", "Are you sure you want to close without saving?"))
       end
       if (key_pressed?(:key_enter) || key_pressed?(:key_space)) && form.index == 10
         if edt_name.text.to_s.strip == ""
@@ -641,11 +643,14 @@ class Scene_Calendar_Management
     ]
     form = Form.new(fields)
     accepted = false
+    init_name = edt_name.text.to_s
     dialog_open
     loop do
       loop_update
       form.update
-      break if key_pressed?(:key_escape) || ((key_pressed?(:key_enter) || key_pressed?(:key_space)) && form.index == 4)
+      if key_pressed?(:key_escape) || ((key_pressed?(:key_enter) || key_pressed?(:key_space)) && form.index == 4)
+        break if edt_name.text.to_s == init_name || confirm(p_("Calendar", "Are you sure you want to close without saving?"))
+      end
       if (key_pressed?(:key_enter) || key_pressed?(:key_space)) && form.index == 3
         if edt_name.text.to_s.strip == ""
           alert(p_("Calendar", "Enter a calendar name"))

--- a/src/scenes/forum.rb
+++ b/src/scenes/forum.rb
@@ -2725,7 +2725,7 @@ form.wait
         end
       end
       if key_pressed?(:key_escape) or form.fields[-1].pressed?
-        if (!form.fields[1].is_a?(EditBox) && form.fields[1].delete_audio) or (form.fields[1].is_a?(EditBox) && (form.fields[1].text=="" || confirm(p_("Forum", "Are you sure you want to cancel creating this thread?"))))
+        if (!form.fields[1].is_a?(EditBox) && (form.fields[0].text=="" || confirm(p_("Forum", "Are you sure you want to cancel creating this thread?"))) && form.fields[1].delete_audio) or (form.fields[1].is_a?(EditBox) && ((form.fields[0].text=="" && form.fields[1].text=="") || confirm(p_("Forum", "Are you sure you want to cancel creating this thread?"))))
         loop_update
         return
         break

--- a/src/scenes/messages.rb
+++ b/src/scenes/messages.rb
@@ -1033,7 +1033,7 @@ def audiolimit
                        end
                      end
                      if (key_pressed?(:key_escape) or ((key_pressed?(:key_enter) or key_pressed?(:key_space)) and @form.index == 7)) && (@form.fields[3]==nil || @form.fields[3].delete_audio)
-                       if (@form.fields[2]==nil || @form.fields[2].text=="") || confirm(p_("Messages", "Are you sure you want to cancel creating this message?"))
+                       if ((@form.fields[2]==nil || @form.fields[2].text=="") && (@form.fields[1]==nil || @form.fields[1].text==@subject.to_s)) || confirm(p_("Messages", "Are you sure you want to cancel creating this message?"))
                                                               if @scene != false and @scene != true and @scene.is_a?(Integer)==false and @scene.is_a?(Array)==false
            $scene = @scene
          else

--- a/src/scenes/notes.rb
+++ b/src/scenes/notes.rb
@@ -240,7 +240,9 @@ class Scene_Notes_New
         @form.fields[2]=btn
         end
       @form.update
-      break if key_pressed?(:key_escape) or ((key_pressed?(:key_enter) or key_pressed?(:key_space)) and @form.index==3)
+      if key_pressed?(:key_escape) or ((key_pressed?(:key_enter) or key_pressed?(:key_space)) and @form.index==3)
+        break if (@form.fields[0].text=="" and @form.fields[1].text=="") or confirm(p_("Notes", "Are you sure you want to close this note without saving?"))
+      end
       if ((key_pressed?(:key_enter) or key_pressed?(:key_space)) and @form.index==2)
         name=@form.fields[0].text
         text=@form.fields[1].text

--- a/src/scenes/tasks.rb
+++ b/src/scenes/tasks.rb
@@ -136,12 +136,16 @@ module TasksSceneHelpers
     end
     accepted = false
     plantime = nil
+    init_name = edt_name.text.to_s
+    init_desc = edt_description.text.to_s
     dialog_open
     loop do
       loop_update
       form.update
-      break if key_pressed?(:key_escape) ||
-        ((key_pressed?(:key_enter) || key_pressed?(:key_space)) && form.index == 7)
+      if key_pressed?(:key_escape) ||
+          ((key_pressed?(:key_enter) || key_pressed?(:key_space)) && form.index == 7)
+        break if (edt_name.text.to_s == init_name && edt_description.text.to_s == init_desc) || confirm(p_("Tasks", "Are you sure you want to close without saving?"))
+      end
       if (key_pressed?(:key_enter) || key_pressed?(:key_space)) && form.index == 6
         if edt_name.text.to_s.strip.empty?
           alert(p_("Tasks", "Enter a task name"))
@@ -327,12 +331,15 @@ class Scene_Tasks_Projects
     ]
     form = Form.new(fields)
     accepted = false
+    init_name = edt_name.text.to_s
     dialog_open
     loop do
       loop_update
       form.update
-      break if key_pressed?(:key_escape) ||
-        ((key_pressed?(:key_enter) || key_pressed?(:key_space)) && form.index == 2)
+      if key_pressed?(:key_escape) ||
+          ((key_pressed?(:key_enter) || key_pressed?(:key_space)) && form.index == 2)
+        break if edt_name.text.to_s == init_name || confirm(p_("Tasks", "Are you sure you want to close without saving?"))
+      end
       if (key_pressed?(:key_enter) || key_pressed?(:key_space)) && form.index == 1
         if edt_name.text.to_s.strip.empty?
           alert(p_("Tasks", "Enter a project name"))


### PR DESCRIPTION
## What changed

Escape (and the Cancel button) now prompt for confirmation before discarding an in-progress editor when any text field has content, across all create/edit editors that previously closed silently:

- Notes — new note (title / content)
- Messages — new message (subject was ignored before; now covered)
- Forum — new thread (thread name was ignored before; both text and voice threads covered)
- Blog — new post (title and excerpt were ignored before; now tracked alongside body)
- Tasks — new task (name / description) and new project (name)
- Calendar — new event (name / description) and new calendar (name)

## Why

These editors only guarded the body/content field (or had no guard at all), so typing a subject, thread name, blog title/excerpt, task/event name, etc. and then pressing Escape discarded the work with no warning. Editors that already had a proper guard (e.g. forum reply, note editing) were left untouched.

## User impact

Consistent behaviour everywhere: if anything is typed into a title OR content field, Escape asks before closing; if all fields are untouched, Escape closes silently as before. For edit dialogs the check compares against the initial values, so leaving an unchanged form (or an unchanged "RE:" reply subject) does not nag.

## Validation

- `ruby -c` syntax check passes on all six changed files.
- Guard booleans verified with an ad-hoc truth-table harness (empty vs. typed vs. edited-untouched vs. edited-changed) — all cases behave as specified.
- Manually tested from source (`bundle exec ruby elten.rb`) in each editor: typing then Escape prompts; empty then Escape closes silently.
