### PR TITLE
Prevent Space activating Edit from leaking into note text

### DIFF
--- a/src/scenes/notes.rb
+++ b/src/scenes/notes.rb
@@ -143,6 +143,7 @@ end
     @form.fields[0].flags=EditBox::Flags::MultiLine
     @form.index=0
     @form.fields[0].focus
+    EltenWindow.take_character(true) if defined?(EltenWindow) && EltenWindow.respond_to?(:take_character)
     @form.fields[1]=Button.new(_("Save"))
   else
     text=@form.fields[0].text


### PR DESCRIPTION
## What changed

When activating the "Edit" button in a note with the Spacebar, the space character also leaked into the note text field, so pressing Space once both switched the note into edit mode **and** inserted a leading space — as if Space had been pressed twice.

This adds a single line that flushes the pending character buffer at the exact moment the note switches from read-only to edit mode, so the activating Space is not consumed by the freshly focused edit box.

## Why

On Windows a single key press produces two separate messages: `WM_KEYDOWN` (read by `key_pressed?`) and `WM_CHAR` (read by the edit box via `getkeychar`). The "Edit" button reacts to `key_pressed?(:key_space)`, immediately makes field 0 editable and focuses it — but the Space character (code 32) is still sitting in the character queue and gets swallowed by the now-editable field on the next frame.

This only affects Space, not Enter: the character filter drops codes below 32, so Enter (13) never leaks, while Space (32) passes through. That is why the double-action was specific to the Spacebar.

## User impact

Blind users navigating notes with a screen reader can now press Space on "Edit" without a stray space being inserted at the caret. Enter and mouse/other activations were never affected and stay unchanged. Typing spaces while editing is unaffected — the buffer is flushed only once, at the transition into edit mode.

## Validation

- `ruby -c src/scenes/notes.rb` → Syntax OK.
- Ran from source (`bundle exec ruby elten.rb`), opened an own note, activated "Edit" with Space: no leading space is inserted, and normal space typing during editing still works.
