### PR TITLE
Confirm before closing Elten from Task View with unsaved text

### DIFF
--- a/src/main.rb
+++ b/src/main.rb
@@ -91,10 +91,14 @@ key_update
 rescue SystemExit
   if $immediateexit!=true
   loop_update
-  quit if key_held?(0x73) || mac_quit_shortcut_request
-          play_sound("listbox_focus") if $exit==nil
-  $toscene = true
-    retry if $exit == nil
+  # A window close was requested (Alt+F4, Task View / taskbar "Close window", window X
+  # button, system menu Close). loop.rb has already decided this should proceed - either
+  # immediately, or after the user confirmed discarding unsaved edits via a native dialog.
+  # So shut Elten down cleanly through the ensure block below; do NOT open the in-app quit
+  # menu, which cannot be focused when the close originates from Task View.
+  # mac_quit_shortcut_request is called for its side effect: consume a pending macOS Cmd+Q.
+  mac_quit_shortcut_request
+  $exit = true
   end
 rescue Exception => error
   if defined?(Programs) && Programs.handle_execution_error(error, $scene)

--- a/src/ui/loop.rb
+++ b/src/ui/loop.rb
@@ -175,7 +175,9 @@ end
         loop_update_window
         sleep(loop_update_tick_seconds)
       update_window_tray_visibility if loop_update_due?(:window_tray_visibility, PERIODIC_FAST_SECONDS, loop_now)
-      raise SystemExit if EltenWindow.consume_close_request
+      if EltenWindow.consume_close_request
+        raise SystemExit unless elten_window_close_cancelled?
+      end
       key_update
       EltenTray.restore_hotkey_pressed? if tray_supported? && defined?(EltenTray) && loop_update_due?(:tray_restore_hotkey, PERIODIC_FAST_SECONDS, loop_now)
       if raw_key_held?(:key_shift) && modifier_held?(:control)
@@ -339,6 +341,56 @@ if $activecontrols!=nil
     end
     return tips
     end
+
+  # Decides what happens when the OS asks Elten to close the window
+  # (Task View / taskbar "Close window", the X button, Alt+F4, system menu Close).
+  # Default behaviour: return false -> the caller exits Elten immediately, with no
+  # in-app quit menu (that menu can't be focused when the request comes from Task View).
+  # Exception: if a live, editable edit box holds unsaved text, bring the window to the
+  # foreground and show a native Yes/No confirmation. Returns true (cancel the close)
+  # unless the user explicitly confirms.
+  def elten_window_close_cancelled?
+    edit = elten_close_unsaved_editbox
+    return false if edit == nil
+    begin
+      EltenWindow.restore_from_tray if EltenWindow.respond_to?(:restore_from_tray)
+    rescue Exception
+    end
+    msg = p_("EAPI_Common", "You have unsaved text in an edit field. Do you want to close Elten anyway?")
+    caption = p_("EAPI_Common", "Close Elten")
+    # MB_YESNO(0x4) | MB_ICONQUESTION(0x20) | MB_DEFBUTTON2(0x100) | MB_SETFOREGROUND(0x10000) | MB_TOPMOST(0x40000)
+    flags = 0x4 | 0x20 | 0x100 | 0x10000 | 0x40000
+    result = EltenWindow.message_box(msg, caption, flags)
+    return result != 6 # IDYES(6) -> close; anything else -> keep Elten open
+  rescue Exception => e
+    Log.warning("Elten close confirmation failed: #{e}") if defined?(Log)
+    false
+  end
+
+  # Returns the first live editable EditBox whose current text differs from the text it
+  # started with (i.e. unsaved user input), or nil when there is nothing worth confirming.
+  def elten_close_unsaved_editbox
+    return nil unless defined?(EltenAPI::Controls::EditBox)
+    seen = {}
+    [$activecontrols, $lastactivecontrols].each do |list|
+      next unless list.is_a?(Array)
+      list.each do |c|
+        next if c == nil || seen[c.object_id]
+        seen[c.object_id] = true
+        next unless c.is_a?(EltenAPI::Controls::EditBox)
+        next if (c.flags.to_i & EltenAPI::Controls::EditBox::Flags::ReadOnly) != 0
+        current = c.text.to_s.gsub("
+\n", "\n")
+        next if current == ""
+        original = c.origtext.to_s.gsub("
+\n", "\n")
+        return c if current != original
+      end
+    end
+    nil
+  rescue Exception
+    nil
+  end
 
   end
 end


### PR DESCRIPTION
## What changed

When Elten receives an OS window-close request (Task View / taskbar "Close window", the X button, Alt+F4, system menu Close) and a live, editable edit box holds **unsaved text**, Elten now shows a native Yes/No confirmation instead of exiting immediately. If no edit field has unsaved text, the close proceeds immediately as before.

- `src/ui/loop.rb`: added `elten_window_close_cancelled?` and `elten_close_unsaved_editbox` helpers. The confirmation dialog uses `MB_SETFOREGROUND | MB_TOPMOST` and restores the window from tray, so it comes to the front even when the close originated from Task View.
- `src/main.rb`: the `rescue SystemExit` path now shuts down cleanly through the `ensure` block instead of opening the in-app quit menu (that menu cannot be focused when the request comes from Task View).

## Why

Closing Elten from Windows Task View discarded unsaved text in an open editor without any prompt, because the in-app quit menu can't take focus when the close originates outside the app. This mirrors the existing in-editor Escape confirmation behaviour for the OS-level close path.

## User impact

Users (especially screen-reader users) no longer silently lose unsaved text when closing Elten from Task View, the taskbar, Alt+F4 or the X button. When there's nothing unsaved, closing is unchanged.

## Validation

- `ruby -c` passes on both changed files.
- Manually tested by the reporter: closing from Task View with text in an edit field triggers the confirmation; with an empty field it closes immediately.

## Note

Because the confirmation originates while another window (Task View) is foreground, Windows' foreground-lock may keep the dialog in the background until the user switches to Elten — this is standard Windows behaviour, not specific to Elten. The `MB_SETFOREGROUND | MB_TOPMOST` flags mitigate it as much as the OS allows.
