### PR TITLE
Change follow/unfollow calendar shortcuts to be more intuitive

### DIFF
--- a/src/scenes/calendar.rb
+++ b/src/scenes/calendar.rb
@@ -806,9 +806,9 @@ class Scene_Calendar_Public
     calendar = current_calendar
     if calendar != nil
       if @subscribed_ids.include?(calendar.id)
-        menu.option(p_("Calendar", "Unsubscribe"), nil, "s") { unsubscribe(calendar) }
+        menu.option(p_("Calendar", "Unsubscribe"), nil, "l") { unsubscribe(calendar) }
       elsif !calendar.owned_by?(Session.name) && !calendar.moderator?
-        menu.option(p_("Calendar", "Subscribe"), nil, "s") { subscribe(calendar) }
+        menu.option(p_("Calendar", "Subscribe"), nil, "l") { subscribe(calendar) }
       end
     end
     if Session.languages.to_s != ""


### PR DESCRIPTION
This changes the public calendar subscribe and unsubscribe shortcuts from Ctrl+S to Ctrl+L.

Ctrl+L is already used for following and unfollowing forums, threads, blogs, and blog posts throughout Elten. Using it for public calendars unifies the interface and matches the shortcut users are already accustomed to.

Forum discussion: https://elten.link/pl/forum/thread/27538

Verification:
- `cmake --preset windows-x64`
- `cmake --build --preset windows-x64-release`