### PR TITLE
Fix notification history name

### DIFF
--- a/src/scenes/notifications.rb
+++ b/src/scenes/notifications.rb
@@ -44,7 +44,7 @@ class Scene_Notifications
     append_virtual_notification_groups(groups, collect_virtual_notification_groups, include_revoked: true)
     @groups = limit_visible_notification_groups(sort_notification_groups(groups))
     @index = [[index.to_i, 0].max, [@groups.size - 1, 0].max].min
-    @list = TableBox.new(notification_columns, notification_rows(@groups), index: @index, header: p_("Notifications", "Notifications"), quiet: false)
+    @list = TableBox.new(notification_columns, notification_rows(@groups), index: @index, header: p_("MainMenu", "Notification hi&story").delete("&"), quiet: false)
     apply_notification_group_states(@list, @groups)
     @list.bind_context { |menu| context(menu) }
   end


### PR DESCRIPTION
Use the existing translated main-menu label for the notification history header and remove its accelerator marker. This keeps the name consistent without asking translators to translate the same label again.

Forum discussion: https://elten.link/pl/forum/thread/27525