### PR TITLE
Fix notification tab focus behavior

### DIFF
--- a/src/scenes/main.rb
+++ b/src/scenes/main.rb
@@ -80,7 +80,7 @@ class Scene_Main
         had_notifications = notifications_visible?
         active = main_window_active?
         minimized = main_window_minimized?
-        notifications_load(false)
+        notifications_load(false, focus_policy: Configuration.mainnotificationfocus)
         @focus_notifications_when_active = true if !had_notifications && notifications_visible? && !active
         if focused_notifications
           if @skip_next_notifications_change_say == true


### PR DESCRIPTION
Apply the configured notification focus policy when the notification list updates, not only when entering the main window. This makes the selected behavior take effect when notifications arrive or finish loading, as reported in the forum thread. The one-time focus override used when returning from the feed remains unchanged.

Forum discussion: https://elten.link/pl/forum/thread/27647