### PR TITLE
Add Shift+Enter hint to older user posts

### DIFF
--- a/src/scenes/forum.rb
+++ b/src/scenes/forum.rb
@@ -4116,7 +4116,7 @@ class Scene_Forum_UserPosts
 
   def rebuild_list(index = nil)
     options = @posts.map { |post| post_label(post) }
-    options << p_("Forum", "Show older") if @more
+    options << p_("Forum", "Show older (Press Shift+Enter to load more posts at once)") if @more
     options << p_("Forum", "No forum posts") if options.empty?
     index = @list.index if index.nil? && @list != nil
     index = 0 if index.nil?


### PR DESCRIPTION
Adds a hint directly to the Show older item in the user posts list, explaining that Shift+Enter loads more posts at once. 
Forum thread: https://elten.link/pl/forum/thread/27469