### PR TITLE
  Queue text input on Linux to stop losing typed characters

### DIFF
--- a/src/platforms/linux/ri/desktopruntime.rb
+++ b/src/platforms/linux/ri/desktopruntime.rb
@@ -154,6 +154,42 @@ module LinuxWindowNative
       ""
     end
 
+    # Characters composed by SDL - including AltGr and IME results - are queued in
+    # typing order and drained here. The per-virtual-key map above cannot do that
+    # job: it is keyed by the key rather than by the keystroke, so it keeps only
+    # the last character typed for a given key and carries no order at all.
+    def take_character(multi = false)
+      @char_queue ||= []
+      @char_frame_consumed = true
+      return "" if @char_queue.empty?
+      return @char_queue.shift.to_s if multi != true
+      text = @char_queue.join
+      @char_queue = []
+      text
+    rescue Exception
+      ""
+    end
+
+    # Called once per input frame. Characters that nobody read for a whole frame
+    # are dropped, so keystrokes made outside an edit control cannot pile up and
+    # then flood the next one that opens.
+    def begin_character_frame
+      @char_queue ||= []
+      @char_queue.shift(@char_frame_prefix.to_i) if @char_frame_consumed != true
+      @char_frame_prefix = @char_queue.size
+      @char_frame_consumed = false
+      true
+    rescue Exception
+      true
+    end
+
+    def clear_character_queue
+      @char_queue = []
+      @char_frame_prefix = 0
+      @char_frame_consumed = false
+      true
+    end
+
     private
 
     def ensure_initialized
@@ -260,6 +296,7 @@ module LinuxWindowNative
       @key_events = []
       @translated_chars = {}
       @last_text_vk = nil
+      clear_character_queue
     end
 
     def text_virtual_key?(key)
@@ -269,14 +306,22 @@ module LinuxWindowNative
     end
 
     def store_text_input(text)
-      return if @last_text_vk == nil
       text = sanitize_text(text)
+      queue_characters(text)
+      return if @last_text_vk == nil
       @translated_chars ||= {}
       if text == ""
         @translated_chars.delete(@last_text_vk)
       else
         @translated_chars[@last_text_vk] = text
       end
+    rescue Exception
+    end
+
+    def queue_characters(text)
+      return if text == ""
+      @char_queue ||= []
+      text.each_char { |char| @char_queue << char }
     rescue Exception
     end
 
@@ -634,6 +679,7 @@ module EltenWindow
 
     def clear_input_state
       @keyboard_state = "\0" * 256
+      LinuxWindowNative.clear_character_queue if @native_window == true && defined?(LinuxWindowNative)
       EltenKeyboard.clear_state
       true
     end
@@ -643,13 +689,16 @@ module EltenWindow
     end
 
     def begin_input_frame
-      return true if @native_window == true
+      if @native_window == true
+        LinuxWindowNative.begin_character_frame if defined?(LinuxWindowNative)
+        return true
+      end
       update_messages
       true
     end
 
     def character_input_supported?
-      false
+      @native_window == true
     end
 
     def keyboard_flags_driven?
@@ -668,7 +717,10 @@ module EltenWindow
       false
     end
 
-    def take_character(_multi = false)
+    def take_character(multi = false)
+      return LinuxWindowNative.take_character(multi) if @native_window == true && defined?(LinuxWindowNative)
+      ""
+    rescue Exception
       ""
     end
 


### PR DESCRIPTION
  The Linux window reported no character input support, so typed text reached
  the application through the fallback path in getkeychar. That path looks at
  the keys pressed during the current frame and returns at most one character
  per frame, chosen by the lowest virtual-key code rather than by the order in
  which the keys were struck. Whenever a single frame absorbed more than one
  keystroke, because speech was starting, a sound was playing or a request was
  being served in the same loop_update, every character but one was discarded,
  and the survivor was not necessarily the one typed first. Characters composed
  by SDL were additionally deleted from the per-key map on SDL_KEYUP, so
  anything outside the US-ASCII fallback table, in particular AltGr results and
  diacritics, silently degraded to the base letter.

  Edit fields speak what arrives, so the loss was easy to mistake for a typing
  error. Password fields only play a sound per character, which is how this
  surfaced: changing an account password reported that the old password was
  incorrect although it had been entered correctly, because the client sent a
  shortened string to the server.

  LinuxWindowNative now keeps the characters composed by SDL_TEXTINPUT in a
  queue in typing order, drained through EltenWindow.take_character with
  character_input_supported? enabled, which is the model already used on
  Windows. begin_input_frame opens a character frame and discards characters
  that nobody read for a whole frame, so keystrokes made outside an edit control
  cannot pile up and flood the next field that opens; clearing the input state
  and losing keyboard focus clear the queue as well. The older per-virtual-key
  map stays in place, because conference key naming still resolves characters
  through it with a synthetic keyboard state.

  One behavioural difference follows: AltGr characters now really reach edit
  fields, so on layouts where AltGr is Ctrl+Alt a shortcut that also produces
  text will insert that text. Windows normalises this case, Linux does not yet.

  Verified by replaying SDL event batches through key_update and getkeychar:
  typing one to nine characters per frame now yields the complete text in
  order, "ą" arrives intact, and characters typed while no control reads them
  do not leak into the next field.
