### PR TITLE
Close window: open quit menu only when a focused edit field has text

### DIFF
--- a/src/main.rb
+++ b/src/main.rb
@@ -8,7 +8,7 @@ class Object
   include EltenAPI
   end
 
-def mac_quit_shortcut_request
+def window_quit_shortcut_request
   EltenWindow.consume_quit_shortcut_request
 rescue Exception
   false
@@ -90,8 +90,26 @@ key_update
   retry
 rescue SystemExit
   if $immediateexit!=true
+  # Capture whether the focused control is an edit box holding text BEFORE loop_update,
+  # which blurs it and clears the handle. EditBox.focused_with_text? is a clean type-aware
+  # check, not a scan of the transient $activecontrols stack.
+  edit_text = defined?(EltenAPI::Controls::EditBox) && EltenAPI::Controls::EditBox.focused_with_text?
   loop_update
-  quit if key_held?(0x73) || mac_quit_shortcut_request
+  if key_held?(0x73) || window_quit_shortcut_request
+    # A window close was requested (the X button, Alt+F4, the system menu Close, or Task
+    # View / taskbar "Close window").
+    if edit_text
+      # Text in the focused edit field: bring the window to the front (so the menu can be
+      # focused when the close came from outside the app) and open Elten's existing quit
+      # menu - the same path macOS uses for Cmd+Q.
+      EltenWindow.restore_from_tray if defined?(EltenWindow) && EltenWindow.respond_to?(:restore_from_tray)
+      quit
+    else
+      # Empty field (or not editing text): close straight away, the same way choosing
+      # "Exit" in the quit menu does (clear the scene and let the main loop shut down).
+      $scene = nil
+    end
+  end
           play_sound("listbox_focus") if $exit==nil
   $toscene = true
     retry if $exit == nil

--- a/src/main.rb
+++ b/src/main.rb
@@ -90,23 +90,13 @@ key_update
   retry
 rescue SystemExit
   if $immediateexit!=true
-  # Capture whether the focused control is an edit box holding text BEFORE loop_update,
-  # which blurs it and clears the handle. EditBox.focused_with_text? is a clean type-aware
-  # check, not a scan of the transient $activecontrols stack.
   edit_text = defined?(EltenAPI::Controls::EditBox) && EltenAPI::Controls::EditBox.focused_with_text?
   loop_update
   if key_held?(0x73) || window_quit_shortcut_request
-    # A window close was requested (the X button, Alt+F4, the system menu Close, or Task
-    # View / taskbar "Close window").
     if edit_text
-      # Text in the focused edit field: bring the window to the front (so the menu can be
-      # focused when the close came from outside the app) and open Elten's existing quit
-      # menu - the same path macOS uses for Cmd+Q.
       EltenWindow.restore_from_tray if defined?(EltenWindow) && EltenWindow.respond_to?(:restore_from_tray)
       quit
     else
-      # Empty field (or not editing text): close straight away, the same way choosing
-      # "Exit" in the quit menu does (clear the scene and let the main loop shut down).
       $scene = nil
     end
   end

--- a/src/platforms/windows/ri/desktopruntime.rb
+++ b/src/platforms/windows/ri/desktopruntime.rb
@@ -646,6 +646,20 @@ module EltenWindow
       end
     end
 
+    # Mirrors the macOS runtime: reports (and clears) whether the last close request
+    # came from a user-initiated window close, so main.rb can open the in-app quit menu
+    # instead of exiting silently. Matches EltenWindow.consume_quit_shortcut_request on
+    # the other platforms.
+    def consume_quit_shortcut_request
+      window_state_monitor.synchronize do
+        requested = @quit_shortcut_requested == true
+        @quit_shortcut_requested = false
+        requested
+      end
+    rescue Exception
+      false
+    end
+
     def consume_minimize_request
       window_state_monitor.synchronize do
         if minimize_request_suppressed?
@@ -1131,20 +1145,24 @@ module EltenWindow
     end
 
     def close_message?(message, wparam, lparam = 0)
+      # A user-initiated window close (the X button, Alt+F4, the system menu Close,
+      # or Task View / taskbar "Close window") should behave like macOS Cmd+Q: mark it
+      # as a quit-shortcut request too, so main.rb opens the in-app quit menu instead of
+      # exiting silently.
       if message == WM_CLOSE
-        window_state_monitor.synchronize { @close_requested = true }
+        window_state_monitor.synchronize { @close_requested = true; @quit_shortcut_requested = true }
         return true
       end
       if message == WM_SYSKEYDOWN && wparam.to_i == VK_F4
         return true if repeated_key_message?(lparam)
         return true if activation_input_blocked?
-        window_state_monitor.synchronize { @close_requested = true }
+        window_state_monitor.synchronize { @close_requested = true; @quit_shortcut_requested = true }
         return true
       end
       return false unless message == WM_SYSCOMMAND
       command = wparam.to_i & 0xfff0
       if command == SC_CLOSE
-        window_state_monitor.synchronize { @close_requested = true }
+        window_state_monitor.synchronize { @close_requested = true; @quit_shortcut_requested = true }
         return true
       end
       false

--- a/src/platforms/windows/ri/desktopruntime.rb
+++ b/src/platforms/windows/ri/desktopruntime.rb
@@ -646,10 +646,6 @@ module EltenWindow
       end
     end
 
-    # Mirrors the macOS runtime: reports (and clears) whether the last close request
-    # came from a user-initiated window close, so main.rb can open the in-app quit menu
-    # instead of exiting silently. Matches EltenWindow.consume_quit_shortcut_request on
-    # the other platforms.
     def consume_quit_shortcut_request
       window_state_monitor.synchronize do
         requested = @quit_shortcut_requested == true
@@ -1145,10 +1141,6 @@ module EltenWindow
     end
 
     def close_message?(message, wparam, lparam = 0)
-      # A user-initiated window close (the X button, Alt+F4, the system menu Close,
-      # or Task View / taskbar "Close window") should behave like macOS Cmd+Q: mark it
-      # as a quit-shortcut request too, so main.rb opens the in-app quit menu instead of
-      # exiting silently.
       if message == WM_CLOSE
         window_state_monitor.synchronize { @close_requested = true; @quit_shortcut_requested = true }
         return true

--- a/src/ui/controls/edit_box.rb
+++ b/src/ui/controls/edit_box.rb
@@ -12,6 +12,23 @@ module EltenAPI
     READ_TEXT_BREAK_PATTERN = /\n|[!?\.,] /.freeze
     @@customactions=[]
     @@lastedits=[]
+    # The single edit box that currently holds focus (nil when the focused control is
+    # not an edit box). Maintained through the focus/blur lifecycle that loop_update
+    # already drives centrally (ui/loop.rb checkControls) - a clean type-aware handle,
+    # not a scan of the transient $activecontrols stack.
+    @@focused=nil
+    def self.focused; @@focused; end
+    # True when the focused control is an editable edit box that currently contains text.
+    # Used to decide whether closing the window should confirm (text present, protect it)
+    # or exit straight away (empty field).
+    def self.focused_with_text?
+      e=@@focused
+      return false unless e.is_a?(EditBox)
+      return false if (e.flags.to_i & Flags::ReadOnly)!=0
+      e.text.to_s!=""
+    rescue Exception
+      false
+    end
     attr_accessor :index
         attr_accessor :flags
     attr_reader :origtext
@@ -1473,6 +1490,7 @@ def value
   text
   end
   def focus(index=nil,count=nil,spk=true)
+    @@focused=self
     pos=50
     pos=index.to_f/(count-1).to_f*100.0 if index!=nil and count!=nil && count!=0
     if !audio?
@@ -1509,6 +1527,7 @@ def value
                               return @audiotext!=nil || @audiostream!=nil || @audioplayer!=nil
                               end
                       def blur
+                        @@focused=nil if @@focused.equal?(self)
                                                 if @audioplayer!=nil && !@audioplayer.paused?
                         @audioplayer.stop
                         end

--- a/src/ui/controls/edit_box.rb
+++ b/src/ui/controls/edit_box.rb
@@ -12,15 +12,8 @@ module EltenAPI
     READ_TEXT_BREAK_PATTERN = /\n|[!?\.,] /.freeze
     @@customactions=[]
     @@lastedits=[]
-    # The single edit box that currently holds focus (nil when the focused control is
-    # not an edit box). Maintained through the focus/blur lifecycle that loop_update
-    # already drives centrally (ui/loop.rb checkControls) - a clean type-aware handle,
-    # not a scan of the transient $activecontrols stack.
     @@focused=nil
     def self.focused; @@focused; end
-    # True when the focused control is an editable edit box that currently contains text.
-    # Used to decide whether closing the window should confirm (text present, protect it)
-    # or exit straight away (empty field).
     def self.focused_with_text?
       e=@@focused
       return false unless e.is_a?(EditBox)


### PR DESCRIPTION
## What

Closing the Elten window (X button, Alt+F4, the system menu Close, and "Close window" from Task View / the taskbar) now behaves like `Cmd+Q` on macOS, but only prompts when it needs to:

- if the focused control is an editable edit box that **holds text** → the window is brought to the front and Elten's existing quit menu opens (Cancel / Hide in Tray / Exit),
- in every other case (empty field, read-only field, or focus is not on an edit box) → the app closes straight away.

Replaces #60. The previous approach based the decision on scanning the global `$activecontrols` / `$lastactivecontrols` stack, which was rightly rejected as fragile. Here the type and state of the focused control are read through a clean layer that `loop_update` already maintains centrally.

## How

- **`src/platforms/windows/ri/desktopruntime.rb`** — `close_message?` (WM_CLOSE, Alt+F4 = WM_SYSKEYDOWN+VK_F4, SC_CLOSE) now also sets `@quit_shortcut_requested` alongside `@close_requested`; adds `consume_quit_shortcut_request` (an exact mirror of the macOS runtime).
- **`src/ui/controls/edit_box.rb`** — the focused edit box is tracked as a single reference through the normal `focus`/`blur` lifecycle (the same one `loop_update` drives in `checkControls`, ui/loop.rb). Adds `EditBox.focused_with_text?` (editable, not ReadOnly, non-empty). This is a type-aware layer, **not** a scan of the transient stack.
- **`src/main.rb`** — helper `mac_quit_shortcut_request` → `window_quit_shortcut_request` (works on every platform). In `rescue SystemExit` the `focused_with_text?` state is captured **before** `loop_update` (which blurs the field and would clear the reference); with text present → `restore_from_tray` + `quit` (the existing menu), otherwise → `$scene = nil` (the exact path the "Exit" choice in the quit menu already uses).

## Why this is safe

- Reuses the existing macOS quit mechanism instead of inventing a new one — minimal surface for bugs.
- Zero reliance on `$activecontrols`; the reference is kept through the same focus/blur cycle Elten already manages centrally.
- The "close immediately" branch takes the existing, proven path (`$scene = nil`), not new exit logic.

## Tests

- `ruby -c` on all 3 changed files → Syntax OK.
- The `focused_with_text?` + focus/blur logic verified on an isolated harness (7/7): no focus, empty field, field with text, ReadOnly field with text, after blur, blur of another field (`equal?` guard), whitespace-only.
- Tested on a live window on Windows with NVDA: closing from Task View with an empty field → closes immediately; with text → opens the quit menu, focusable.

Elten has no unit-test suite, and the runtime uses Fiddle / window handles so it cannot be loaded standalone — hence syntax check + logic harness + live test.
