### PR TITLE
Refactor: replace for-in with each in backend files

### DIFF
--- a/src/eapi/audio/bass.rb
+++ b/src/eapi/audio/bass.rb
@@ -46,7 +46,7 @@ module EltenBassStructs
     def bass_channel_info_values(buffer)
       filename_offset = POINTER_SIZE == 8 ? 32 : 28
       values = []
-      for i in 0...7
+      (0...7).each do |i|
         values.push(dword_value(buffer, i * 4))
       end
       values.push(pointer_value(buffer, filename_offset))
@@ -489,7 +489,7 @@ return if @init==true
       raise(error_name)
     end
     plugins = ["bassopus", "bassflac", "bassmidi", "basswebm", "basswma", "bass_aac", "bass_ac3", "bass_spx", "basshls", "bassalac"]
-        for pl in plugins
+        plugins.each do |pl|
               Log.debug("Loading Bass plugin #{pl}")
           plugin_path = EltenRuntimePaths.absolute_library_file(pl)
           if BASS_PluginLoad.call(plugin_path, 0) == 0
@@ -614,7 +614,7 @@ class VST
   def parameters
     cnt = BASS_VST_GetParamCount.call(@vst)
     params=[]
-    for i in 0...cnt
+    (0...cnt).each do |i|
       params.push(Parameter.new(@vst, i))
     end
     params
@@ -679,7 +679,7 @@ class VST
   def programs
     count = BASS_VST_GetProgramCount.call(@vst)
     programs=[]
-    for i in 0...count
+    (0...count).each do |i|
       ptr = BASS_VST_GetProgramName.call(@vst, i)
       programs[i]=Bass.c_string(ptr).force_encoding("UTF-8")
     end

--- a/src/eapi/audio/recorder.rb
+++ b/src/eapi/audio/recorder.rb
@@ -59,7 +59,7 @@ module EltenRecorderStructs
     def bass_channel_info_values(buffer)
       filename_offset = POINTER_SIZE == 8 ? 32 : 28
       values = []
-      for i in 0...7
+      (0...7).each do |i|
         values.push(dword_value(buffer, i * 4))
       end
       values.push(pointer_value(buffer, filename_offset))
@@ -247,7 +247,7 @@ module EltenRecorderRuntime
       tags = {}
       ai = AudioInfo.new(channel)
       chapters = ai.chapters
-      for i in 0...chapters.size
+      (0...chapters.size).each do |i|
         chapter = chapters[i]
         key = sprintf("CHAPTER%03d", i)
         time = chapter.time.to_f

--- a/src/eapi/audio/sound.rb
+++ b/src/eapi/audio/sound.rb
@@ -192,7 +192,7 @@ class AudioInfo
           when :UTF16
             content = deunicode(content)
           when :UnicodeFFE
-            for i in 0...content.bytesize / 2
+            (0...content.bytesize / 2).each do |i|
               s = i * 2
               c = content[s]
               content[s] = content[s + 1]
@@ -220,13 +220,13 @@ class AudioInfo
     if t != nil
       tgs = {}
       mapper = {"TIT2" => "TITLE", "TALB" => "ALBUM", "TPE1" => "ARTIST", "TRCK" => "TRACKNUMBER", "TCOM" => "COMPOSER", "TCOP" => "COPYRIGHT"}
-      for d, o in mapper
+      mapper.each do |d, o|
         f = t.find { |frame| frame.id == d }
         tgs[o] = f.strvalue if f != nil
       end
       chs = t.select { |frame| frame.id == "CHAP" }
       i = 0
-      for c in chs
+      chs.each do |c|
         time = c.numvalue / 1000.0
         name = ""
         sf = c.subframes.find { |s| s.id == "TIT2" }
@@ -266,7 +266,7 @@ class AudioInfo
     return @chapters if @chapters != nil && @chapters != []
     chapters = []
     if (t = tags_ogg) != nil
-      for i in 0..999
+      (0..999).each do |i|
         d = sprintf("%03d", i)
         if t["CHAPTER#{d}"] != nil && t["CHAPTER#{d}NAME"] != nil
           tm = t["CHAPTER#{d}"]
@@ -281,12 +281,12 @@ class AudioInfo
       end
     end
     if (t = tags_id3v2) != nil
-      for f in t
+      t.each do |f|
         if f.id == "CHAP" && f.subframes.size > 0
           c = Chapter.new
           c.time = f.numvalue / 1000.0
           c.name = ""
-          for g in f.subframes
+          f.subframes.each do |g|
             c.name = g.strvalue if g.id == "TIT2"
           end
           chapters.push(c)
@@ -304,7 +304,7 @@ class AudioInfo
       return t[ogg.upcase] if t[ogg.upcase] != nil
     end
     if (t = tags_id3v2) != nil
-      for r in t
+      t.each do |r|
         return r.strvalue[0...r.strvalue.index("\0") || r.strvalue.size] if r.id == id3
       end
     end

--- a/src/eapi/audio/speexdsp.rb
+++ b/src/eapi/audio/speexdsp.rb
@@ -90,7 +90,7 @@ return b
 end
 def set_echo(ec)
 return nil if !ec.is_a?(Echo)
-for i in 0...@preprocessors.size
+(0...@preprocessors.size).each do |i|
 pc=EltenNativeStructs.pointer_buffer(ec.echoes[i])
 Preprocess_ctl.call(@preprocessors[i], SPEEX_PREPROCESS_SET_ECHO_STATE, pc)
 end
@@ -109,7 +109,7 @@ while (audio.bytesize-index)>=@stepsize
 frg=audio.byteslice(index...index+@stepsize)
 channels=[]
 sources=frg.unpack("s*").each_slice(@ch).to_a.transpose
-for c in 0...@ch
+(0...@ch).each do |c|
 frame=sources[c].pack("s*")
 Preprocess_run.call(@preprocessors[c], frame)
 channels[c]=frame.unpack("s*")
@@ -126,7 +126,7 @@ return ""
 end
 private
 def setctl_int(flag, value)
-for pr in @preprocessors
+@preprocessors.each do |pr|
 pc=[value].pack("i")
 Preprocess_ctl.call(pr, flag, pc)
 end
@@ -137,7 +137,7 @@ Preprocess_ctl.call(@preprocessors[0], flag, pc)
 return pc.unpack("i").first
 end
 def setctl_float(flag, value)
-for pr in @preprocessors
+@preprocessors.each do |pr|
 pc=[value].pack("f")
 Preprocess_ctl.call(pr, flag, pc)
 end
@@ -173,10 +173,10 @@ return indata if indata.bytesize>outdata.bytesize
 return indata if indata.bytesize!=@stepsize
 indata=indata.byteslice(0...outdata.bytesize) if indata.bytesize>outdata.bytesize
 out="\0"*indata.bytesize
-for c in 0...@ch
+(0...@ch).each do |c|
 inframe=("\0"*(@stepsize/@ch)).b
 outframe=("\0"*(@stepsize/@ch)).b
-for i in 0...(@stepsize/@ch/2)
+(0...(@stepsize/@ch/2)).each do |i|
 inframe.setbyte(i*2, indata.getbyte(2*(@ch*i+c)))
 outframe.setbyte(i*2, outdata.getbyte(2*(@ch*i+c)))
 inframe.setbyte(i*2+1, indata.getbyte(2*(@ch*i+c)+1))
@@ -184,7 +184,7 @@ outframe.setbyte(i*2+1, outdata.getbyte(2*(@ch*i+c)+1))
 end
 resframe="\0"*inframe.bytesize
 Echo_cancellation.call(@echoes[c], inframe, outframe, resframe)
-for i in 0...@stepsize/@ch/2
+(0...@stepsize/@ch/2).each do |i|
 out.setbyte(2*(@ch*i+c), resframe.getbyte(i*2))
 out.setbyte(2*(@ch*i+c)+1, resframe.getbyte(i*2+1))
 end
@@ -198,15 +198,15 @@ ret=""
 while (audio.bytesize-index)>=@stepsize
 frg=audio.byteslice(index...index+@stepsize)
 out=("\0"*@stepsize).b
-for c in 0...@ch
+(0...@ch).each do |c|
 frame=("\0"*(@stepsize/@ch)).b
 resframe="\0"*frame.bytesize
-for i in 0...(@stepsize/@ch/2)
+(0...(@stepsize/@ch/2)).each do |i|
 frame.setbyte(i*2, frg.getbyte(2*(@ch*i+c)))
 frame.setbyte(i*2+1, frg.getbyte(2*(@ch*i+c)+1))
 end
 Echo_capture.call(@echoes[c], frame, resframe)
-for i in 0...@stepsize/@ch/2
+(0...@stepsize/@ch/2).each do |i|
 out.setbyte(2*(@ch*i+c), resframe.getbyte(i*2))
 out.setbyte(2*(@ch*i+c)+1, resframe.getbyte(i*2+1))
 end
@@ -224,15 +224,15 @@ ret=""
 while (audio.bytesize-index)>=@stepsize
 frg=audio.byteslice(index...index+@stepsize)
 out=("\0"*@stepsize).b
-for c in 0...@ch
+(0...@ch).each do |c|
 frame=("\0"*(@stepsize/@ch)).b
 resframe="\0"*frame.bytesize
-for i in 0...(@stepsize/@ch/2)
+(0...(@stepsize/@ch/2)).each do |i|
 frame.setbyte(i*2, frg.getbyte(2*(@ch*i+c)))
 frame.setbyte(i*2+1, frg.getbyte(2*(@ch*i+c)+1))
 end
 Echo_playback.call(@echoes[c], frame, resframe)
-for i in 0...@stepsize/@ch/2
+(0...@stepsize/@ch/2).each do |i|
 out.setbyte(2*(@ch*i+c), resframe.getbyte(i*2))
 out.setbyte(2*(@ch*i+c)+1, resframe.getbyte(i*2+1))
 end
@@ -245,7 +245,7 @@ return ret
 end
 private
 def setctl_int(flag, value)
-for pr in @echoes
+@echoes.each do |pr|
 pc=[value].pack("i")
 Echo_ctl.call(pr, flag, pc)
 end
@@ -256,7 +256,7 @@ Echo_ctl.call(@echoes[0], flag, pc)
 return pc.unpack("i").first
 end
 def setctl_float(flag, value)
-for pr in @echoes
+@echoes.each do |pr|
 pc=[value].pack("f")
 Echo_ctl.call(pr, flag, pc)
 end

--- a/src/eapi/dictionary.rb
+++ b/src/eapi/dictionary.rb
@@ -63,7 +63,7 @@ module EltenAPI
      def getlocale(code)
        normalized=normalize_locale_code(code)
        lang=nil
-     for l in Languages
+     Languages.each do |l|
       if l.realcode.downcase==normalized.downcase
         lang=l
         break
@@ -74,7 +74,7 @@ module EltenAPI
        def setlocale(code)
     code=normalize_locale_code(code)
     lang=nil
-    for l in Languages
+    Languages.each do |l|
       if l.realcode.downcase==code.downcase
         lang=l
         break
@@ -87,7 +87,7 @@ module EltenAPI
    if defined?(Programs) && Programs.respond_to?(:language_locale_data)
      Programs.language_locale_data(code).each { |data| loadmo(data, false) }
    end
- for d in lang.docs
+ lang.docs.each do |d|
    Docs[d[0]]=d[1]
    end
 end
@@ -118,7 +118,7 @@ end
   Params[1]+=n
   src=data[12..15].unpack("I").first
   dst=data[16..19].unpack("I").first
-  for i in 0...n
+  (0...n).each do |i|
 src_length = data[src+8*i..src+8*i+3].unpack("I").first
 src_offset = data[src+8*i+4..src+8*i+7].unpack("I").first
 dst_length = data[dst+8*i..dst+8*i+3].unpack("I").first
@@ -156,7 +156,7 @@ def n_(*pr)
  end
  forms=[]
  n=0
- for param in pr
+ pr.each do |param|
    if param.is_a?(String)
    forms.push(param)
  elsif param.is_a?(Integer)
@@ -266,14 +266,14 @@ end
 def find(*forms)
   c=DictCache[forms.first]
   return forms if c==nil
-  for i in c
+  c.each do |i|
     return Translations[i].map{|s|s.force_encoding(Encoding::UTF_8)} if Sources[i].size>=forms.size && Sources[i][0...forms.size]==forms
   end
   return forms.map{|s|s.force_encoding(Encoding::UTF_8)}
 end
 def setparams(t)
   pr=t.split("\n")
-  for param in pr
+  pr.each do |param|
     c=param.index(": ")
     next if c==nil
     head=param[0...c]

--- a/src/eapi/log.rb
+++ b/src/eapi/log.rb
@@ -87,7 +87,7 @@ end
         lg=[]
         lgh=[]
 last=nil
-        for i in 0...Events.size
+        (0...Events.size).each do |i|
   l=Events[i]
   txt=l.to_s(dsplevel, dspdate)
   if l.level==nil

--- a/src/eapi/structs.rb
+++ b/src/eapi/structs.rb
@@ -52,7 +52,7 @@ module EltenAPI
         attr_accessor :listtype, :usepan, :soundcard, :microphone, :controlspresentation, :contextmenubar, :soundthemeactivation, :typingecho, :linewrapping, :hidewindow, :synctime, :registeractivity, :voice, :language, :voicerate, :voicevolume, :soundtheme, :volume, :usefx, :bgsounds, :voicepitch, :usedenoising, :autologin, :roundupforms, :checkupdates, :enablebraille, :useechocancellation, :usevoicedictionary, :disablefeednotifications, :maintabs, :showemptynotifications, :mainnotificationfocus, :iimodifiers, :iicards, :usebilinearhrtf, :sessiontime, :disablehttp2, :tcpconferences, :udppacketsize, :conferencesaudiobuffer , :conferencesaudiobuffercutoff, :disableconferencemiconrecord, :enableaudiobuffering, :saytimeperiod, :saytimetype, :autoplay, :branch, :keyboardscheme, :macoscharacternavigation, :requestresponsecachemode
         def to_h
           h={}
-          for v in instance_variables
+          instance_variables.each do |v|
             h[v[1..-1]]=instance_variable_get(v)
             end
           return h

--- a/src/ri/__ri.rb
+++ b/src/ri/__ri.rb
@@ -84,7 +84,7 @@ class Array
   end    
   def to_s
     r="["
-    for i in 0...self.size
+    (0...self.size).each do |i|
       r+=", " if i>0
       r+=self[i].to_s
       end
@@ -94,7 +94,7 @@ class Array
     def shuffle
 t=self+[]      
 res=[]
-for o in t
+t.each do |o|
   v=-1
   while v==-1 or res[v]!=nil
   v=rand(t.size)
@@ -105,7 +105,7 @@ for o in t
   end
   def shuffle!
     n=shuffle
-    for i in 0..n.size-1
+    (0..n.size-1).each do |i|
       self[i]=n[i]
       end
     return self
@@ -125,7 +125,7 @@ polsorter(a,b)
   end
   def polsort!
     a=self.polsort
-    for i in 0...self.size
+    (0...self.size).each do |i|
       self[i]=a[i]
       end
     end
@@ -154,13 +154,13 @@ class String
     self.gsub!(EltenLink::LEGACY_LINE,"\r\n") if defined?(EltenLink)
     str = ""
 foundlines = 1
-    for i in 0..self.size - 1
+    (0..self.size - 1).each do |i|
       str += self[i..i]
       foundlines += 1 if self[i..i] == "\n"
     end
     fl = 0
     ret = ""
-    for i in 0..str.size - 1
+    (0..str.size - 1).each do |i|
       fl += 1 if str[i..i] == "\r" or (str[i..i] == "\n" and str[i-1..i-1] != "\r")
       if foundlines - lines > fl
         ret += str[i..i]
@@ -171,14 +171,14 @@ foundlines = 1
     def rdelete!(i)
     b = i[0]
   x = 0
-  for i in 1..self.size
+  (1..self.size).each do |i|
     if self[self.size - i] == b
       x += 1
     else
       break
     end
        end
-  for i in 0..x-1
+  (0..x-1).each do |i|
     chop!
     end
   end
@@ -228,7 +228,7 @@ string=r
     string = self+""
     from=["ą","ć","ę","ł","ń","ó","ś","ź","ż","Ą","Ć","Ę","Ń","Ó","Ł","Ś","Ź","Ż","-"]
     to=["a","c","e","l","n","o","s","z","z","A","C","E","L","N","O","S","Z","Z","_"]
-    for i in 0..to.size-1
+    (0..to.size-1).each do |i|
       string.gsub!(from[i],to[i])
       end
     r = string.gsub(/([^ a-zA-Z0-9_.-]+)/) do |m|

--- a/src/ri/nativestructs.rb
+++ b/src/ri/nativestructs.rb
@@ -31,7 +31,7 @@ module EltenNativeStructs
 
     def pointer_array_values(buffer, count)
       values = []
-      for i in 0...count.to_i
+      (0...count.to_i).each do |i|
         values.push(pointer_value(buffer, i * POINTER_SIZE))
       end
       values
@@ -75,7 +75,7 @@ module EltenNativeStructs
     def bass_channel_info_values(buffer)
       filename_offset = POINTER_SIZE == 8 ? 32 : 28
       values = []
-      for i in 0...7
+      (0...7).each do |i|
         values.push(dword_value(buffer, i * 4))
       end
       values.push(pointer_value(buffer, filename_offset))


### PR DESCRIPTION
## Summary

Replaces `for VAR in EXPR` with `EXPR.each do |VAR|` in 9 pure backend files. No scenes, UI, or speech/accessibility files are touched.

**Files changed:**
- `src/eapi/audio/bass.rb` — BASS library bindings (4 loops)
- `src/eapi/audio/speexdsp.rb` — Speex DSP bindings (15 loops)
- `src/eapi/audio/recorder.rb` — audio recorder (2 loops)
- `src/eapi/audio/sound.rb` — audio metadata/tags (6 loops)
- `src/eapi/structs.rb` — configuration struct (1 loop)
- `src/eapi/log.rb` — logging (1 loop)
- `src/eapi/dictionary.rb` — i18n/MO parser (7 loops)
- `src/ri/__ri.rb` — Array/String extensions (9 loops)
- `src/ri/nativestructs.rb` — native struct helpers (2 loops)

No behaviour changes. Each substitution is one-to-one with no scoping or logic differences.

## Test plan

- [ ] Run Elten and confirm audio playback, recording, and logging work as before
- [ ] Confirm i18n/translation functions correctly