### PR TITLE
Let a group founder delete a group that still contains forums

### DIFF
--- a/src/scenes/forum.rb
+++ b/src/scenes/forum.rb
@@ -916,11 +916,14 @@ if (((@sgroups[@grpsel.index - @grpheadindex].role==1 || (@sgroups[@grpsel.index
       @grpsel.focus
       }
         end
-      if @sgroups[@grpsel.index - @grpheadindex].forums == 0 and @sgroups[@grpsel.index - @grpheadindex].founder == Session.name
+      if @sgroups[@grpsel.index - @grpheadindex].founder == Session.name
         menu.option(p_("Forum", "Delete group")) {
-          confirm(p_("Forum", "Are you sure you want to delete %{groupname}?")%{ :groupname => @sgroups[@grpsel.index - @grpheadindex].name }) {
+          delgroup = @sgroups[@grpsel.index - @grpheadindex]
+          delmsg = p_("Forum", "Are you sure you want to delete %{groupname}?")%{ :groupname => delgroup.name }
+          delmsg += "\r\n" + p_("Forum", "This group still contains forums with all their threads and posts. Deleting the group will permanently delete all of them.") if delgroup.forums > 0
+          confirm(delmsg) {
           if forum_attempt(nil) {
-            EltenLink::Forum.delete_group(elten_link, group_id: @sgroups[@grpsel.index - @grpheadindex].id)
+            EltenLink::Forum.delete_group(elten_link, group_id: delgroup.id)
           }
               alert(p_("Forum", "Group has been deleted"))
             end


### PR DESCRIPTION
## What changed

The "Delete group" option in the forum group context menu was only shown when the
group had **zero forums** (`forums == 0`). This made it impossible to even reach the
delete action for a group that still contained forums. This change shows "Delete
group" to the group **founder** regardless of how many forums the group contains,
and, when the group is not empty, the confirmation dialog appends a warning that all
forums, threads and posts will be permanently deleted along with the group.

## Why

Reported on the forum (by Julitka): a group administrator cannot delete their own
group unless they first remove all of its forums. The action itself and the client
API (`EltenLink::Forum.delete_group`) already existed — only the visibility guard
prevented reaching it on a non-empty group.

## Important: server-side change still required

This PR only fixes the **client** half. Tested live against the current server:
deleting a non-empty group is rejected by the server with

```
success:false, error.code = "forum.group_not_empty", message = "Group still has forums"
(DELETE /api/v1/forum/group/{id})
```

So after this change the option is reachable and confirmed, but for a non-empty
group the server still refuses and the user sees the generic "Error" alert (handled
gracefully by the existing `forum_attempt` wrapper — no crash). To make deletion of
a non-empty group actually work, the **server** needs to cascade-delete the group's
forums/threads/posts (or expose a force flag). Once the server allows it, this
client change starts working with no further edits. For an empty group the behaviour
is unchanged and works today.

## User impact

- The founder (administrator) of a group now sees "Delete group" in the context menu
  even when the group still contains forums.
- Non-founders still do not see the option (unchanged — founder-only).
- For a non-empty group the confirmation prompt warns about the permanent cascade
  before the user confirms.

## Validation

- `ruby -c src/scenes/forum.rb` -> Syntax OK.
- Ad-hoc logic harness (guard + message builder): option VISIBLE for founder with or
  without forums; HIDDEN for non-founder; cascade warning present only when
  `forums > 0`; base message always includes the group name. All assertions pass.
- Live test: option now appears on a founder's non-empty group and asks for
  confirmation; the server rejects the deletion with `forum.group_not_empty` (see
  above), which is the expected server-side blocker documented in this PR.
- The new English warning string uses `p_(...)`, which falls back to English when
  untranslated (no locale changes included).
