### PR TITLE
Fix Windows autostart: use native path and open a visible window

### DIFF
--- a/src/platforms/windows/ri/systemhelpers.rb
+++ b/src/platforms/windows/ri/systemhelpers.rb
@@ -382,7 +382,7 @@ module EltenSystemHelpers
     end
 
     def autostart_command(path)
-      "\"#{path}\" /hidden"
+      "\"#{path.to_s.tr("/", "\\")}\""
     end
 
     def sync_autostart(enabled, command)


### PR DESCRIPTION
## What changed

`EltenSystemHelpers.autostart_command` (Windows) now writes the executable
path to the `HKCU\...\CurrentVersion\Run` value with **backslashes** instead
of forward slashes, and **no longer appends the `/hidden` flag**.

Before:

```ruby
def autostart_command(path)
  "\"#{path}\" /hidden"
end
```

After:

```ruby
def autostart_command(path)
  "\"#{path.to_s.tr("/", "\\")}\""
end
```

## Why

Two separate defects made "Start Elten after signing in" effectively broken
for a blind user:

1. **Forward slashes in the Run value.** `current_executable_path`
   (`runtime.rb`, via `File.expand_path`) yields a path with forward slashes
   (`C:/Program Files (x86)/ELTEN/elten.exe`). The Windows logon shell runs
   the raw string from the `Run` key with `CreateProcess`, and a command
   whose program path uses `/` does not launch reliably at logon. Evidence:
   after a fresh boot there was no `Starting Elten` line in `elten.log`
   although the `Run` value was present and correct, and every other working
   `Run` entry on the machine (OneDrive, Opera, Teams, Edge...) uses
   backslashes — only Elten used `/`. Manual tests with `Start-Process` /
   `Invoke-Item` masked the problem because those APIs normalize the path.

2. **The `/hidden` flag.** Even when it did start, `/hidden` launches Elten
   straight into the system tray with no window, no focus and no sound
   (`loading.rb` skips `EltenWindow.show`). For a screen-reader user this is
   indistinguishable from "nothing happened" — there is zero signal that the
   app is running.

## User impact

Autostart now (1) actually launches at logon because the `Run` command uses a
native Windows path, and (2) opens the normal Elten window instead of starting
silently in the tray, so a blind user gets the usual startup and can start
working immediately.

## Validation

- Ruby syntax check on `systemhelpers.rb`: `ruby -c` → `Syntax OK`.
- Logic check of the built command for
  `C:/Program Files (x86)/ELTEN/elten.exe`:
  produces `"C:\Program Files (x86)\ELTEN\elten.exe"` — contains no `/hidden`
  and no forward slash in the path.
- The equivalent local workaround (a Startup `.lnk` with a backslash target
  and empty arguments) was confirmed on the affected machine to launch Elten
  with a visible window at logon.
