### PR TITLE
Confirm before discarding an unsaved blog comment

### DIFF
--- a/src/scenes/blog.rb
+++ b/src/scenes/blog.rb
@@ -711,10 +711,13 @@ if (key_pressed?(:key_enter) or key_pressed?(:key_space)) and @form.index == @fo
     $scene = Scene_Blog_PostEditor.new(@post.owner,@post.id,@category,@categoryselindex,@postselindex)
     end
   if key_pressed?(:key_escape) or ((key_pressed?(:key_enter) or key_pressed?(:key_space)) and @form.index == @form.fields.size - 1)
+    cf = @form.fields[@form.fields.size - 4]
+    if cf == nil or cf.text == "" or cf.text == "\r\n" or confirm(p_("Blog", "Are you sure you want to cancel creating this comment?"))
 if @scene == nil
     $scene = Scene_Blog_Posts.new(@post.owner,@category,@categoryselindex,@postselindex, @search, @page)
   else
     $scene = @scene
+    end
     end
   end
 end


### PR DESCRIPTION
## What changed

When cancelling the comment editor on a blog post (pressing Escape, or activating the "Return" button), Elten now asks for confirmation if the comment field contains text, instead of discarding it silently.

## Why

Every other new-content editor in Elten (new thread, new post reply, new message, new blog post) already prompts "Are you sure you want to cancel creating this ...?" before throwing away unsaved text. The blog comment editor was the exception: pressing Escape left the post view immediately and lost whatever the user had typed, with no warning. This is especially harmful for screen-reader users, who can easily hit Escape by habit.

## User impact

- Comment field has text + Escape / "Return" -> confirmation dialog ("Are you sure you want to cancel creating this comment?"). Choosing No keeps the user in the editor with their text intact.
- Comment field empty (or commenting disabled / user logged out, when the field is nil) -> leaves immediately, no prompt, exactly as before.

## Validation

- `ruby -c src/scenes/blog.rb` -> Syntax OK.
- Tested live from source (`bundle exec ruby elten.rb`): typing a comment then Escape shows the confirmation; empty field + Escape exits without a prompt.
