### PR TITLE
Add option to delete forum mentions from history

### DIFF
--- a/src/eltenlink/forum.rb
+++ b/src/eltenlink/forum.rb
@@ -473,6 +473,11 @@ module EltenLink
         true
       end
 
+      def delete_mention(client, mention_id:)
+        client.api_data("DELETE", "/api/v1/forum/mention/#{mention_id.to_i}", {})
+        true
+      end
+
       def list_forum_tags(client, forumid:)
         data = client.api_data("GET", "/api/v1/forum/forum/#{forumid.to_i}/tags")
         data["tags"].to_a.map { |row| build_tag(row) }

--- a/src/scenes/forum.rb
+++ b/src/scenes/forum.rb
@@ -2305,6 +2305,19 @@ threadopen(@thrsel.index)
         threadopen(@thrsel.index)
       }
       thread = @sthreads[@thrsel.index]
+      if (@forum == -7 || @forum == -11) && thread.mention != nil
+        menu.option(p_("Forum", "Delete mention"), nil, "-") {
+          if confirm(p_("Forum", "Do you really want to delete this mention from %{user}?")%{ :user => thread.mention.author })
+            if forum_attempt(nil) {
+              EltenLink::Forum.delete_mention(elten_link, mention_id: thread.mention.id)
+            }
+              alert(p_("Forum", "The mention has been deleted."))
+              @lastthreadindex = @thrsel.index
+              threadsmain(@forum)
+            end
+          end
+        }
+      end
       if thread.readposts < thread.posts
         menu.option(p_("Forum", "Mark this thread as read"), nil, "w") {
           unread = thread.posts - thread.readposts
@@ -2422,7 +2435,7 @@ threadopen(@thrsel.index)
             end
           end
         }
-        m.option(p_("Forum", "Delete thread"), nil, "-") {
+        m.option(p_("Forum", "Delete thread"), nil, (@forum == -7 || @forum == -11) ? "" : "-") {
           confirm(p_("Forum", "Do you really want to delete thread %{thrname}?")%{ :thrname => @sthreads[@thrsel.index].name }) do
             if forum_attempt(nil) {
               EltenLink::Forum.delete_thread(elten_link, thread_id: @sthreads[@thrsel.index].id)


### PR DESCRIPTION
## What changed

Adds the ability to delete a received mention from the forum mentions history
(both "Received mentions" and the full mentions view).

- New client API method `EltenLink::Forum.delete_mention` calling
  `DELETE /api/v1/forum/mention/{id}` (mirrors the existing `notice_mention`
  which uses `PATCH /api/v1/forum/mention/{id}/noticed`).
- New "Delete mention" option in the mentions-list context menu, shown only in
  the mentions views (`-7`, `-11`) and only when a mention object is present.
  It asks for confirmation, then reloads the list.
- The option uses the `-` accelerator, so it is also available as a global
  `Ctrl+-` shortcut on the focused mention without opening the context menu —
  the same mechanism the "Delete thread" option already relies on.
- To avoid a `Ctrl+-` collision inside the mentions views, the moderator
  "Delete thread" option drops its `-` accelerator there (the menu entry
  itself stays). Everywhere else "Delete thread" keeps `Ctrl+-` unchanged.

## Why

Users had no way to remove entries from their mentions history. Once a mention
was received it stayed in the list permanently.

## User impact

On a focused mention: `Ctrl+-` (or context menu → "Delete mention") asks for
confirmation and removes it. No behaviour change outside the mentions views.

## Server dependency (please note)

The client side is complete, but the server currently has no delete route for a
mention. `DELETE /api/v1/forum/mention/{id}` returns:

```
code=common.not_found, message="Resource not found"
```

(verified live against a mention that exists in the list). Until the server
implements the delete endpoint, confirming the action shows a plain "Error"
(caught by `forum_attempt`, no crash). The delete resource lookup follows the
same REST convention already used for threads (`DELETE /api/v1/forum/{id}`) and
posts (`DELETE /api/v1/forum/post/{id}`).

## Validation

- `ruby -c` on both changed files: Syntax OK.
- Ad-hoc logic harness: "Delete mention" shows only in views `-7`/`-11` with a
  mention present and is hidden elsewhere / when the mention is nil; the
  `Ctrl+-` accelerator belongs to delete-mention in the mentions views and to
  "Delete thread" everywhere else.
- Live: `Ctrl+-` prompts for confirmation and issues the DELETE request; server
  response captured above.
