### PR TITLE
Silence spurious border sound when navigating headings

### DIFF
--- a/src/ui/controls/edit_box.rb
+++ b/src/ui/controls/edit_box.rb
@@ -205,6 +205,7 @@ url=nil
   if e!=nil
     @index=e.from
     espeech(text_range(e.from,e.to))
+    EltenWindow.take_character(true) if defined?(EltenWindow) && EltenWindow.respond_to?(:take_character)
     elsif (character=getkeychar)!=""
     play_sound("border") unless audio? && character==" "
     end


### PR DESCRIPTION
## What changed

Flush the pending typed character right after a successful in-text navigation jump in a read-only `EditBox` (heading, link and list-item shortcuts), so it no longer leaks into the next frame.

## Why

Pressing `H` (or the `1`–`6`, `k`, `i` shortcuts) inside a read-only HTML/Markdown `EditBox` produces two Windows messages for the single key press:

- `WM_KEYDOWN`, read by the navigation handler in `readupdate`, which finds the target element and moves the caret;
- `WM_CHAR`, carrying the typed character (`h`, a digit, …), pushed onto the character queue.

Since the character queue is no longer cleared on every input frame, that stray character survived into the next frame, where `getkeychar` consumed it and hit the `play_sound("border")` branch — so a spurious error sound fired after *every* successful jump, making it sound as if navigation had failed even though the caret had moved correctly.

## User impact

Screen-reader users navigating blog posts and other read-only rich-text fields by heading (or link / list item) no longer hear a false error beep after each jump. The jump itself already worked; only the misleading sound is removed.

## Validation

- `ruby -c src/ui/controls/edit_box.rb` → `Syntax OK`.
- Live test in a blog post with headings: `H` and `1`–`6` move between headings with speech and **no** border sound; typing in an editable field (including spaces) is unaffected; the border sound still fires when there is no further heading or on a genuinely unhandled key.

The one-line flush mirrors the already-merged fix for the same class of stray-character bug in `notes.rb` (#59), and runs only on a successful jump so it cannot swallow characters typed during editing.
