### PR TITLE
Open blog comment notifications at first unread comment

### DIFF
--- a/src/eapi/notificationgroups.rb
+++ b/src/eapi/notificationgroups.rb
@@ -999,7 +999,8 @@ module NotificationGroups
     post.author = payload["author"].to_s
     post.followed = true if cat.to_s == "followedblogpost"
     post.mention = blog_mention_from_payload(payload) if cat.to_s == "blogmention" && payload["mentionid"].to_i > 0
-    insert_scene(Scene_Blog_Read.new(post, -1, 0, 0, Scene_Main.new), true, return_to_main: true)
+    first_unread = ["blogcomment", "followedblogpost"].include?(cat.to_s)
+    insert_scene(Scene_Blog_Read.new(post, -1, 0, 0, Scene_Main.new, first_unread: first_unread), true, return_to_main: true)
   end
 
   def blog_mention_from_payload(payload)

--- a/src/scenes/blog.rb
+++ b/src/scenes/blog.rb
@@ -551,7 +551,7 @@ end
 end
   
 class Scene_Blog_Read
-  def initialize(post,category,categoryselindex=0,postselindex=0,scene=nil,page=0,search=nil)
+  def initialize(post,category,categoryselindex=0,postselindex=0,scene=nil,page=0,search=nil,first_unread: false)
     @post=post
     @category = category
         @categoryselindex = categoryselindex
@@ -559,6 +559,7 @@ class Scene_Blog_Read
     @scene=scene
 @page=page
 @search=search
+@first_unread=first_unread
     @isowner=(blogowners(post.owner)||"").include?(Session.name)
           end
   def main
@@ -659,7 +660,8 @@ else
   @fields.push(nil)
   end
 @fields.push(Button.new(p_("Blog", "Return")))
-@form = Form.new(@fields)
+@postcur=@knownposts+2 if @first_unread && @knownposts<@posts.size
+@form = Form.new(@fields,index: @postcur)
 if @comments==0
   @form.fields[-3]=nil
   @form.fields[-4]=nil


### PR DESCRIPTION
Blog comment notifications now open the first unread comment by using the same known-post index as the existing Go to first unread comment action.

The change builds successfully and should behave as intended, but manual verification was not possible because blog comment notifications are currently not working.

Forum thread: https://elten.link/pl/forum/thread/27477