### PR TITLE
Allow cancelling premium currency selection

### DIFF
--- a/src/scenes/premiumpackages.rb
+++ b/src/scenes/premiumpackages.rb
@@ -138,7 +138,7 @@ show(package)
     }
   end
   def select_currency
-    c = selector([p_("PremiumPackages", "Polish zloty")+" (PLN)", p_("PremiumPackages", "Euro")+" (EUR)", p_("PremiumPackages", "US dollar")+" (USD)", p_("PremiumPackages", "British pound")+" (GBP)"], header: p_("PremiumPackages", "Select your currency."))
+    c = selector([p_("PremiumPackages", "Polish zloty")+" (PLN)", p_("PremiumPackages", "Euro")+" (EUR)", p_("PremiumPackages", "US dollar")+" (USD)", p_("PremiumPackages", "British pound")+" (GBP)"], header: p_("PremiumPackages", "Select your currency."), cancel_index: -1)
     return if c < 0 || c >= CURRENCIES.size
     @currency = CURRENCIES[c]
     LocalConfig['PremiumPackagesCurrency'] = @currency


### PR DESCRIPTION
The currency selector in Premium packages can now be cancelled with Escape without changing the current currency.

Forum thread: https://elten.link/pl/forum/thread/27717