### PR TITLE
Move program install options to bottom of context menu with shortcuts

### DIFF
--- a/src/scenes/programs.rb
+++ b/src/scenes/programs.rb
@@ -36,17 +36,14 @@ end
          $scene=Scene_Main.new if $scene==self
      end
      def context(menu)
-       menu.option(p_("Programs", "Install from file")) {
-         install_from_file
-       }
-       menu.option(p_("Programs", "Install from server")) {
-         install_from_server
-       }
        menu.option(p_("Programs", "Check for updates")) {
          check_updates
        }
        program=@all[@sel.index]
-       return if program==nil
+       if program==nil
+         add_install_options(menu)
+         return
+       end
        menu.option(p_("Programs", "Details")) {
          show_program_details(program)
        }
@@ -86,6 +83,16 @@ when 1
              @refresh=true
            }
          end
+       }
+       add_install_options(menu)
+     end
+
+     def add_install_options(menu)
+       menu.option(p_("Programs", "Install new program from server"), nil, "i") {
+         install_from_server
+       }
+       menu.option(p_("Programs", "Install new program from file"), nil, "I") {
+         install_from_file
        }
      end
 


### PR DESCRIPTION
## What changed

Move the "Install from file" and "Install from server" options in the Programs management scene (`Scene_Programs`) from the top of the context menu to the bottom, rename them to "Install new program from server" and "Install new program from file", and give them `Ctrl+I` / `Ctrl+Shift+I` accelerators. The two options are grouped into a single `add_install_options` helper so they render both when a program is selected and when the list is empty.

## Why

Installing a new program is a rarely used action, yet it sat above the per-program actions (Details, Load, Unload, Uninstall) in the context menu, pushing the common actions down. The old labels ("Install from file/server") were also ambiguous about installing a *new* program.

## User impact

- The context menu of Programs management now lists per-program actions first; the two install-new-program options appear at the bottom, server first, then file.
- `Ctrl+I` installs a new program from the server and `Ctrl+Shift+I` from a file, working directly on the list without opening the menu.
- Clearer labels state that a new program is being installed.

## Validation

- `ruby -c src/scenes/programs.rb` -> Syntax OK.
- Ran from source and confirmed in a live NVDA session: the install options appear at the bottom of the context menu in the stated order, the `Ctrl+I` / `Ctrl+Shift+I` shortcuts trigger the server list / file picker, and the options are also present when the installed-programs list is empty.
