### PR TITLE
Do not defer context menu request raised inside a menu

### DIFF
--- a/src/eapi/quickactions.rb
+++ b/src/eapi/quickactions.rb
@@ -66,7 +66,7 @@ module EltenAPI
             scene == nil ? alert(p_("Notifications", "There is nothing new."), false) : insert_scene(scene)
           end
         when :context
-                   $opencontextmenu=true
+                   $opencontextmenu=true if !GlobalMenu.opened?
         when :lastspeech
           speak($speech_lasttext)
           when :copylastspeech


### PR DESCRIPTION
## What changed

Guard the "Open context menu" quick action so it only sets the deferred
`$opencontextmenu` flag when no global menu is currently open:

```
when :context
  $opencontextmenu=true if !GlobalMenu.opened?
```

## Why

The quick action set `$opencontextmenu=true` unconditionally. The main loop
only consumes that flag while `!GlobalMenu.opened?` (see `keyprocs` in
`ui/input.rb`), so a context-menu request raised *inside* a global submenu
could not fire immediately. It stayed latched and was consumed one step later,
in the next scene.

Concretely: open the main menu, go to Programs, press the context-menu key,
then activate "Programs management". The pending request leaked into the
Programs list scene and popped a context menu there instead of just opening
the list. Scenes reached directly (e.g. Blogs) were unaffected, because the
context key is pressed in a normal scene where the flag is consumed on the
same frame.

This matches the existing pattern in the same `case`: the `:whatsnew` branch
right above already guards with `if !GlobalMenu.opened?`.

## User impact

Opening a scene from a submenu no longer triggers a stray context menu one
step later. Normal context-menu usage inside scenes is unchanged.

## Validation

- `ruby -c` on the changed file: Syntax OK.
- `bundle check`: dependencies satisfied.
- Isolated logic check of the guarded statement: with a menu open the flag
  stays unset; with menus closed it is set as before.
- Live test from source (`bundle exec ruby elten.rb`): Programs -> context
  menu -> Programs management now opens the list directly; context menus in
  scenes still work.
