### PR TITLE
Reset to default sound theme when deleting the active one

### DIFF
--- a/src/scenes/soundthemes.rb
+++ b/src/scenes/soundthemes.rb
@@ -54,7 +54,13 @@ stdownload
           }
           menu.option(p_("SoundThemes", "Delete"), nil, :del) {
                           confirm(p_("SoundThemes", "Are you sure you want to delete the sound theme %{soundtheme}?")%{ :soundtheme => @soundthemes[@sel.index].name}) {
-                File.delete(@soundthemes[@sel.index].file)
+                theme=@soundthemes[@sel.index]
+                File.delete(theme.file)
+                if Configuration.soundtheme!=nil && File.basename(theme.file, ".elsnd")==Configuration.soundtheme
+                  Configuration.soundtheme=nil
+                  use_soundtheme("")
+                  writeconfig("Interface", "SoundTheme", Configuration.soundtheme)
+                end
                 @return=true
                 main
                 }


### PR DESCRIPTION
## What changed
When deleting the currently active sound theme in `Scene_SoundThemes`, Elten now falls back to the default theme and clears the saved `SoundTheme` configuration, instead of only deleting the file.

## Why
`context`'s Delete option called `File.delete` on the theme file but never touched the in-memory theme (`@@soundtheme`) or the configuration. The active theme's sounds are held in RAM (`SoundTheme#sounds`), so they kept playing after deletion until the app was restarted.

## User impact
Deleting the active sound theme now immediately switches playback back to the default theme, matching what users expect. Deleting a non-active theme is unaffected.

## Validation
- `ruby -c src/scenes/soundthemes.rb` → Syntax OK.
- Ran from source, selected a theme, deleted it while active → playback returns to default without restart; config `[Interface] SoundTheme` cleared.
- Deleting a non-active theme leaves the active one untouched.
