### PR TITLE
Split conference user mute into separate chat and dice roll options

### DIFF
--- a/src/eapi/conference.rb
+++ b/src/eapi/conference.rb
@@ -116,6 +116,8 @@ class Channel
     @@channels=nil
 @@volumes={}
 @@streamid_mutes={}
+@@chat_mutes_local=[]
+@@dice_mutes_local=[]
 @@mystreams=Streams.new
 @@streams=[]
 @@channel=Channel.new
@@ -361,10 +363,12 @@ def self.attach_core_callbacks(conf)
   conf.on_waitinguser {|joined, username| announce_user(joined ? "conference_userknock" : "conference_userleave", username)}
   conf.on_speaker {|status, username, _userid| announce_speaker(status, username)}
   conf.on_text {|username, userid, message|
+    next if chat_muted_local?(username)
     settext(username, userid, message)
     announce_text(username, message, "conference_message")
   }
   conf.on_diceroll {|username, userid, value, count|
+    next if dice_muted_local?(username)
     setdiceroll(username, userid, value, count)
     announce_text(username, value.to_s, "conference_diceroll")
   }
@@ -868,6 +872,26 @@ def self.setvstbank(prm)
   def self.texts
   return @@texts
 end
+def self.chat_muted_local?(user)
+  @@chat_mutes_local.include?(user)
+end
+def self.dice_muted_local?(user)
+  @@dice_mutes_local.include?(user)
+end
+def self.set_chat_mute_local(user, mute)
+  if mute
+    @@chat_mutes_local.push(user) if !@@chat_mutes_local.include?(user)
+  else
+    @@chat_mutes_local.delete(user)
+  end
+end
+def self.set_dice_mute_local(user, mute)
+  if mute
+    @@dice_mutes_local.push(user) if !@@dice_mutes_local.include?(user)
+  else
+    @@dice_mutes_local.delete(user)
+  end
+end
 def self.waiting_channel_id
   @@waiting_channel_id
   end
@@ -966,6 +990,8 @@ end
             @@channels=nil
 @@volumes={}
 @@streamid_mutes={}
+@@chat_mutes_local=[]
+@@dice_mutes_local=[]
 @@mystreams=Streams.new
 @@streams=[]
 @@channel=Channel.new

--- a/src/scenes/conference.rb
+++ b/src/scenes/conference.rb
@@ -98,14 +98,24 @@ class Scene_Conference
               speak(p_("Conference", "User unmuted"))
               end
       }
-      s=p_("Conference", "Mute user's chat messages and dice rolls")
-      s=p_("Conference", "Unmute user's chat messages and dice rolls") if vol.chat_muted==true
+      s=p_("Conference", "Mute user's chat messages")
+      s=p_("Conference", "Unmute user's chat messages") if Conference.chat_muted_local?(user.name)
       menu.option(s, nil, "e") {
-            Conference.setvolume(user.name, vol.volume, vol.muted, !vol.chat_muted, vol.streams_muted)
-            if !vol.chat_muted
+            Conference.set_chat_mute_local(user.name, !Conference.chat_muted_local?(user.name))
+            if Conference.chat_muted_local?(user.name)
               speak(p_("Conference", "User's chat muted"))
             else
               speak(p_("Conference", "User's chat unmuted"))
+              end
+      }
+      s=p_("Conference", "Mute user's dice rolls")
+      s=p_("Conference", "Unmute user's dice rolls") if Conference.dice_muted_local?(user.name)
+      menu.option(s, nil, "E") {
+            Conference.set_dice_mute_local(user.name, !Conference.dice_muted_local?(user.name))
+            if Conference.dice_muted_local?(user.name)
+              speak(p_("Conference", "User's dice rolls muted"))
+            else
+              speak(p_("Conference", "User's dice rolls unmuted"))
               end
       }
       s=p_("Conference", "Mute user's streams")


### PR DESCRIPTION
## What changed

Split the single conference user context-menu option "Mute user's chat messages and dice rolls" (Ctrl+E) into two independent options:

- "Mute user's chat messages" — Ctrl+E
- "Mute user's dice rolls" — Ctrl+Shift+E

## Why

The old option called the server-side `chat_mute` command, which mutes chat messages (packet type 2) and dice rolls (type 101) together with a single flag. There was no way to mute only a user's dice rolls while still hearing their messages (or vice versa). The server exposes no separate command for dice rolls.

## How

Chat messages and dice rolls arrive at the client through separate hooks (`on_text` / `on_diceroll` in `attach_core_callbacks`). The fix stops routing this through the server `chat_mute` and instead filters locally:

- Two local lists `@@chat_mutes_local` / `@@dice_mutes_local`, initialized alongside the other conference state and reset in `setclosed`.
- Getter/setter helpers `chat_muted_local?` / `dice_muted_local?` / `set_chat_mute_local` / `set_dice_mute_local`.
- Each hook short-circuits with `next` for a locally muted user, suppressing the announcement, sound, and chat-history entry.

This mirrors the existing `locally_muted` pattern already used for streams.

## User impact

The context menu on a user now has one more option, and chat vs dice can be muted independently. Muting is per-session and client-local (cleared when leaving the conference) — unlike the previous server-side mute which persisted. This is a necessary trade-off: because the server has no dice-only command, independent muting can only be done client-side. Persistent/server-side split muting would require a server change.

Note: the server-side `chat_mute` / `chat_unmute` code paths are left untouched; they are simply no longer invoked from this menu.

## Validation

- `ruby -c` syntax check on both changed files: OK.
- Ad-hoc logic harness (10/10): verified independence in both directions (mute dice only leaves chat audible and vice versa) and toggle idempotency.
- Live-tested in a running conference: muting only dice rolls silences dice while chat messages are still heard, and muting only chat messages silences chat while dice rolls are still heard.
