### PR TITLE
Prevent Escape on missing-tags warning from sending the thread

### DIFF
--- a/src/scenes/forum.rb
+++ b/src/scenes/forum.rb
@@ -2839,12 +2839,12 @@ form.wait
     confirm_missing_tag = lambda {
       missing_tag_field = current_tag_fields.find { |field| field.index == 0 }
       return true if missing_tag_field == nil
-      if confirm(p_("Forum", "You haven't selected all tags. Do you want to select the missing tags?"))
+      if confirm(p_("Forum", "You haven't selected all tags. Do you want to send the thread anyway?"))
+        true
+      else
         form.index = form.fields.index(missing_tag_field)
         form.focus
         false
-      else
-        true
       end
     }
     confirm_closed_forum = lambda {


### PR DESCRIPTION
## What changed

Reworded and reversed the "missing tags" confirmation shown when sending a new thread without all required tags, so that dismissing the dialog with Escape (or choosing the default option) no longer sends the thread.

## Why

When a thread was missing required tags, the confirmation asked "Do you want to select the missing tags?" with options No / Yes. Because `confirm` returns `false` for both the "No" option and for Escape (ui/dialogs.rb), and the default highlighted option is "No", the safe action (go back and add tags) required actively choosing "Yes". Pressing Escape — which normally cancels and returns to the form — instead sent the thread with no tags, as did a plain Enter on the default option. This is the opposite of what the warning implies.

## User impact

The dialog now asks "Do you want to send the thread anyway?". The thread is only sent when the user explicitly confirms with "Yes". Escape, "No", and the default option all cancel sending and return focus to the missing-tag field so the user can pick the tags. Escape no longer publishes a thread without tags.

## Validation

- `ruby -c src/scenes/forum.rb` -> Syntax OK.
- `bundle check` -> dependencies satisfied.
- Manual live test pending (thread editor: send with missing tags, then Escape must return to the tag field and NOT publish).
