### PR TITLE
Tolerate one second of overshoot in feed audio duration check

### DIFF
--- a/src/eapi/eltensrv/feeds.rb
+++ b/src/eapi/eltensrv/feeds.rb
@@ -101,7 +101,7 @@ module EltenAPI
           audio=nil
           if recorder!=nil && !recorder.empty?
             duration=recorder.source_duration
-            if duration!=nil && duration>audio_max_duration
+            if duration!=nil && duration>audio_max_duration+1
               choice=selector(
                 [
                   p_("FeedViewer", "Shorten the audio to %{limit} seconds") % {:limit=>audio_max_duration},


### PR DESCRIPTION
## What changed

Allow one second of tolerance in the feed audio duration check (`compose_feed`, `src/eapi/eltensrv/feeds.rb`). The client now shows the "shorten to N seconds" dialog only when the recording exceeds the limit by more than one second, instead of on any overshoot.

## Why

Recording stops on a timer at exactly the limit (60 s), but the capture buffer is flushed after the timer fires, so the finished file ends up slightly longer than the limit. Measured on a real recording: the timer stopped at 60 s, yet the saved file was 60.04 s. `source_duration.ceil` then reported 61 s and the client blocked a recording that is, for all practical purposes, at the limit. The server already tolerates this small overshoot.

## User impact

A recording that hits the timer limit now publishes without the spurious "the audio is 61 seconds, the maximum is 60" prompt. The nominal 60 s limit is unchanged, genuinely over-long files (e.g. imported from disk) are still caught, and a server rejection is still handled by the existing `audio.too_long` path.

## Validation

- Measured real recordings with ffmpeg: a timer-stopped recording came out to 60.04 s.
- Reproduced the false dialog on the current build (RC 1) with that file.
- With the patch, the same 60.04 s file publishes without the dialog.
