### PR TITLE
Add Ctrl+minus shortcut to permanent delete in forum trash

### DIFF
--- a/src/scenes/forum.rb
+++ b/src/scenes/forum.rb
@@ -4747,7 +4747,7 @@ class Scene_Forum_Trash
 
     menu.option(p_("Forum", "Open")) { open_thread(thread) }
     if !thread.trashed && thread.contains_trashed_posts
-      menu.option(p_("Forum", "Delete all trashed posts permanently")) {
+      menu.option(p_("Forum", "Delete all trashed posts permanently"), nil, "-") {
         mutate(
           p_("Forum", "Permanently delete all posts from thread %{thread} that are currently in the trash? This cannot be undone.") % {
             thread: thread.name
@@ -4787,7 +4787,7 @@ class Scene_Forum_Trash
         }
       end
     }
-    menu.option(p_("Forum", "Delete permanently")) {
+    menu.option(p_("Forum", "Delete permanently"), nil, "-") {
       mutate(
         p_("Forum", "Permanently delete thread %{thread} together with all its posts? This cannot be undone.") % {
           thread: thread.name
@@ -4831,7 +4831,7 @@ class Scene_Forum_Trash
         }
       end
     }
-    menu.option(p_("Forum", "Delete permanently")) {
+    menu.option(p_("Forum", "Delete permanently"), nil, "-") {
       mutate(
         p_("Forum", "Permanently delete this post by %{user}? This cannot be undone.") % { user: post.author },
         p_("Forum", "The post has been permanently deleted."),


### PR DESCRIPTION
## What changed

Add the Ctrl+\- accelerator to the permanent-delete options in the forum trash context menus (`Scene_Forum_Trash`): "Delete permanently" for a thread, "Delete permanently" for a post, and "Delete all trashed posts permanently".

## Why

The regular forum menus bind Ctrl+\- to "Delete thread" and "Delete post", but the trash menus offered permanent delete with no shortcut, so the key users expect from the forum did nothing in the trash. This makes the trash consistent with the rest of the forum.
