### PR TITLE
Add a shortcut for sharing notes

### DIFF
--- a/src/scenes/notes.rb
+++ b/src/scenes/notes.rb
@@ -89,8 +89,9 @@ sharest=shares+[]
 @form=Form.new(@fields)
 @form.bind_context{|menu|
 if note.author==Session.name
-menu.option(p_("Notes", "Share")) {
+menu.option(p_("Notes", "Share"), nil, "n") {
         inpt=EditBox.new(p_("Notes", "Who do you want to share this note with?"))
+    inpt.focus
     loop do
       loop_update
       inpt.update


### PR DESCRIPTION
Adds Ctrl+N as a shortcut for the existing Share option in an owned note.

While adding the shortcut, the focus of the user input field was also fixed. Previously, the field was not focused when opened, so its label was not announced by the screen reader.

Forum thread: https://elten.link/pl/forum/thread/27811
