### PR TITLE
Add option to pin a program to quick actions

### DIFF
--- a/src/scenes/programs.rb
+++ b/src/scenes/programs.rb
@@ -92,6 +92,16 @@ when 1
            }
          end
        }
+       program_class=program_scene_class(program)
+       if program_class!=nil
+         menu.option(p_("Programs", "Add this program to quick actions"), nil, "q") {
+           if QuickActions.create(program_class, program.name.to_s+" (#{p_("Programs", "Program")})")
+             alert(p_("Programs", "Program added to quick actions"), false)
+           else
+             alert(_("Error"))
+           end
+         }
+       end
        add_install_options(menu)
      end
 
@@ -729,6 +739,12 @@ when 1
      def program_uuid(program)
        return "" if program==nil || !program.respond_to?(:id)
        program.id.to_s.downcase
+     end
+
+     def program_scene_class(program)
+       uuid=program_uuid(program)
+       return nil if uuid==""
+       Programs.list.find{|cls| cls.respond_to?(:app_uuid) && cls.app_uuid.to_s.downcase==uuid}
      end
 
      def same_program?(a,b)


### PR DESCRIPTION
## What changed

Reworked the "Add this program to quick actions" context option in
`Scene_Programs` per review feedback. The quick action now pins the program's
declared main class directly, exactly like launching it from the Programs
submenu (`m.scene(label, prg)` in mainmenu.rb). The previous redirect through
`Scene_Programs` (with a serialized UUID target and an in-scene launcher) is
gone.

Two small helpers replace the old machinery:
- `program_scene_class(program)` looks up the loaded `Program` subclass by
  `app_uuid` (case-insensitive) and is used both to gate the menu option (only
  shown when the class is resolvable) and to pin it.
- The menu option calls `QuickActions.create(program_class, label)` with no
  params, so on activation `QuickActions` resolves and instantiates the class
  the same way the submenu does.

This works across restarts because the program namespace is deterministic
(`EltenPrograms::P<uuid-hex>`) and `Programs.load_all` loads every enabled
program at boot, so `QuickActions.resolve_scene` (`Object.const_get`) finds the
class by its stable full name.

## Why

The reviewer flagged the redirect through `Scene_Programs` as over-engineered:
a quick action should target the program's main class directly, the way the
menu already does, instead of routing through the management scene.

## User impact

Unchanged from the user's point of view: on a program entry in "Programs
management", the context menu offers "Add this program to quick actions"
(Ctrl+Q). Activating the pinned action launches the program directly.

## Validation

- `ruby -c src/scenes/programs.rb` -> Syntax OK.
- Ad-hoc harness (8/8 PASS): `program_scene_class` uuid lookup
  (exact/case-insensitive/no-match/empty/empty-list) and the QuickActions
  round-trip (a Class serializes to its full name and `Object.const_get`
  resolves the nested namespace path back).
- Live launch/restore-after-restart tested in the running client (pending).
