### PR TITLE
Show developer mode in window title

### DIFF
--- a/elten.rb
+++ b/elten.rb
@@ -18,7 +18,11 @@ module Elten
     end
 
     def window_title
-      VERSION_STRING
+      VERSION_STRING + ($developer_mode == true ? " DEV" : "")
+    end
+
+    def window_titles
+      [window_title, VERSION_STRING, "Elten"].uniq
     end
 
     def build_id
@@ -189,7 +193,7 @@ module EltenBoot
       set_active_window = Fiddle::Function.new(user32["SetActiveWindow"], [type_ptr], type_ptr)
       set_focus = Fiddle::Function.new(user32["SetFocus"], [type_ptr], type_ptr)
       hwnd = nil
-      [Elten.window_title, "Elten"].uniq.each do |title|
+      Elten.window_titles.each do |title|
         hwnd = find_window.call(wide_string(WINDOWS_MAIN_CLASS), wide_string(title))
         break if hwnd != nil && hwnd.to_i != 0
       end


### PR DESCRIPTION
## What changed

`Elten.window_title` now appends ` DEV` to the version string when the client
runs in developer mode (`$developer_mode == true`). In stable/normal mode the
title is unchanged (`ELTEN 3.0.2`); in developer mode it becomes `ELTEN 3.0.2 DEV`.

Title selection is expressed with a plain ternary concatenation instead of a
`return unless` guard, matching the surrounding style.

The list of titles used by the single-instance detection is now a small helper,
`Elten.window_titles` (`[window_title, VERSION_STRING, "Elten"].uniq`).
`activate_existing_instance` iterates that helper, so a developer-mode process
still finds and focuses an already running stable instance (and vice versa)
instead of spawning a second window on the same data directory, without the
inline literal array at the call site.

## Why

There was no way to tell from the window title whether a running client was a
stable build or a developer build launched from source. Screen reader users in
particular rely on the window title announcement to know which instance they are
in when both are present.

## User impact

- Developer-mode window title is announced as "ELTEN 3.0.2 DEV".
- Normal builds are unaffected.
- Single-instance activation keeps working across both title variants.

## Validation

- `ruby -c elten.rb` -> Syntax OK.
- Verified against the real module loaded from elten.rb: `window_title` returns
  `ELTEN 3.0.2` for `$developer_mode` nil/false and `ELTEN 3.0.2 DEV` for true;
  `window_titles` de-duplicates correctly in both states.
- `$developer_mode` is set before `create_window` at boot, so the title is
  correct from the first window creation.
