### PR TITLE
Add option to call all members of a group conversation

### DIFF
--- a/src/scenes/messages.rb
+++ b/src/scenes/messages.rb
@@ -286,6 +286,9 @@ if @users[@sel_users.index].user[0..0]=="["
   edit_conversation(@users[@sel_users.index])
   @sel_users.focus
   }
+  menu.option(p_("Messages", "Call"), nil, "c") {
+    call_group(@users[@sel_users.index])
+  }
 menu.option(p_("Messages", "Leave")) {
     confirm(p_("Messages", "Are you sure you want to leave this group?")) {
     begin
@@ -423,6 +426,20 @@ if form.fields[2]!=nil and form.fields[2].pressed?
   end
     end
     loop_update
+  end
+  def call_group(u)
+    begin
+      members=EltenLink::Messages.group_users(elten_link, u.user)
+    rescue EltenLink::Error
+      alert(_("Error"))
+      return
+    end
+    members=members.reject{|m|m==Session.name}
+    if members.size==0
+      alert(p_("Messages", "There is nobody to call in this conversation."))
+      return
+    end
+    voicecall(nil, nil, members)
   end
   def mute_conversation(u, time=false)
     begin


### PR DESCRIPTION
## What changed

Added a "Call" option to the context menu of group conversations in Messages
(Shift+F10 / accelerator Ctrl+C on a group conversation). Selecting it starts a
voice call inviting every member of that conversation at once.

A new `call_group` helper fetches the conversation members via
`EltenLink::Messages.group_users`, drops the current user, and passes the rest to
the existing `voicecall(nil, nil, members)` path (the same one already used by
"Call this user", which accepts an array of invitees).

## Why

Group conversations had no quick way to start a call with everyone in them; users
had to invite people one by one from inside a conference. Forum request: start a
call to all members of a group conversation straight from the Messages list.

## User impact

On a group conversation (entries prefixed with "["), the context menu now shows
"Call". It rings every other member simultaneously. If the group has no other
members, it reports that there is nobody to call instead of opening an empty
conference. Single (non-group) conversations are unaffected.

## Validation

- `ruby -c src/scenes/messages.rb` -> Syntax OK.
- Reuses the verified `voicecall` invite-array path and existing
  `group_users` API; no server changes.
- Live test in the running client (rings all members) pending.
