### PR TITLE
fix: preserve interface language across updates and sync with Inno Setup

### DIFF
--- a/launcher/installer/inst_elten.iss
+++ b/launcher/installer/inst_elten.iss
@@ -62,10 +62,9 @@ Name: "{commondesktop}\ELTEN"; Filename: "{app}\elten.exe"; Tasks: desktopicon
 Filename: "{app}\elten.exe"; Description: "{cm:LaunchProgram,{#StringChange("ELTEN", '&', '&&')}}"; Flags: nowait postinstall
 
 [INI]
-Filename: "{userappdata}\elten\elten.ini"; Section: "Interface"; Key: "Language"; String: "de-DE"; Languages: de
-Filename: "{userappdata}\elten\elten.ini"; Section: "Interface"; Key: "Language"; String: "pl-PL"; Languages: pl
-Filename: "{userappdata}\elten\elten.ini"; Section: "Interface"; Key: "Language"; String: "fr-FR"; Languages: fr
-Filename: "{userappdata}\elten\elten.ini"; Section: "Interface"; Key: "Language"; String: "ru-RU"; Languages: ru
-Filename: "{userappdata}\elten\elten.ini"; Section: "Interface"; Key: "Language"; String: "es-PA"; Languages: es
-Filename: "{userappdata}\elten\elten.ini"; Section: "Interface"; Key: "Language"; String: "tr-TR"; Languages: tr
-
+Filename: "{userappdata}\elten\elten.ini"; Section: "Interface"; Key: "Language"; String: "de-DE"; Languages: de; Flags: createkeyifdoesntexist
+Filename: "{userappdata}\elten\elten.ini"; Section: "Interface"; Key: "Language"; String: "pl-PL"; Languages: pl; Flags: createkeyifdoesntexist
+Filename: "{userappdata}\elten\elten.ini"; Section: "Interface"; Key: "Language"; String: "fr-FR"; Languages: fr; Flags: createkeyifdoesntexist
+Filename: "{userappdata}\elten\elten.ini"; Section: "Interface"; Key: "Language"; String: "ru-RU"; Languages: ru; Flags: createkeyifdoesntexist
+Filename: "{userappdata}\elten\elten.ini"; Section: "Interface"; Key: "Language"; String: "es-PA"; Languages: es; Flags: createkeyifdoesntexist
+Filename: "{userappdata}\elten\elten.ini"; Section: "Interface"; Key: "Language"; String: "tr-TR"; Languages: tr; Flags: createkeyifdoesntexist


### PR DESCRIPTION
Preserves the user's manually selected interface language across updates and synchronizes the active language with Inno Setup.

Addresses the issue reported on the Elten PC Betatests forum (Thread 21688: "[Błąd] [Interfejs] Zmiana ręcznie ustawionego języka po aktualizacji").

### Problem
When updating Elten silently on Windows:
1. In `launcher/installer/inst_elten.iss`, the `[INI]` section lacked the `Flags: createkeyifdoesntexist` directive. As a result, Inno Setup unconditionally overwrote `[Interface] Language` in `elten.ini` with whichever language the installer ran in.
2. In `src/platforms/windows/ri/systemhelpers.rb`, `update_install_command` launched `eltenup.exe` without the `/LANG=<id>` parameter, causing Inno Setup to fall back to the initial installation language stored in the Windows registry uninstaller key.

### Changes
1. `launcher/installer/inst_elten.iss`:
   - Added `Flags: createkeyifdoesntexist` to existing `[INI]` language entries so that existing user language preferences in `elten.ini` are never overwritten on update or reinstall.
   - Preserved the existing language set and native English fallback without injecting extraneous defaults.
2. `src/platforms/windows/ri/systemhelpers.rb`:
   - Added `installer_language_code` to resolve the current active language (from `Configuration.language` or `readconfig`) to the corresponding Inno Setup language tag (`en`, `pl`, `de`, `fr`, `ru`, `es`, `tr`).
   - Appended `/LANG=#{inno_lang}` to the installer command when a matching language is detected (gracefully omitting it for unsupported locales).
3. `src/eapi/common/platform.rb`:
   - Updated `platform_update_install_command` to accept an optional `language` parameter with backward compatibility.
