### PR TITLE
Fix return navigation from contact addition notification

### DIFF
--- a/src/eapi/notificationgroups.rb
+++ b/src/eapi/notificationgroups.rb
@@ -930,7 +930,7 @@ module NotificationGroups
     when "blogfollower"
       Proc.new { insert_scene(Scene_Blog_Followers.new(nil), true, return_to_main: true) }
     when "friend"
-      Proc.new { insert_scene(Scene_Users_AddedMeToContacts.new(true), true) }
+      Proc.new { insert_scene(Scene_Users_AddedMeToContacts.new(true, Scene_Main.new), true, return_to_main: true) }
     when "birthday"
       Proc.new { open_birthday(payload) }
     when "groupinvitation"

--- a/src/scenes/usersaddedmetocontacts.rb
+++ b/src/scenes/usersaddedmetocontacts.rb
@@ -5,8 +5,9 @@
 # You should have received a copy of the GNU General Public License along with Elten. If not, see <https://www.gnu.org/licenses/>. 
 
 class Scene_Users_AddedMeToContacts
-  def initialize(new=false)
+  def initialize(new=false, scene=nil)
     @new=new
+    @scene=scene
     end
   def main
     unless Session.logged?
@@ -40,11 +41,7 @@ loop_update
         rescue EltenLink::Error => e
           Log.warning("Users added me acknowledgement failed: #{e.message}")
         end
-        if @new==false
-        $scene = Scene_Main.new
-      else
-        $scene=Scene_Notifications.new
-        end
+        $scene = @scene || Scene_Main.new
         break
       end
       if key_pressed?(:key_enter)


### PR DESCRIPTION
### Problem
When pressing Escape or Left Arrow in the "Users who added me to their contact list" notification scene, the user was routed directly to Scene_Notifications.new (Notification History) instead of returning to the main window or the originating scene.

### Solution
- Updated `Scene_Users_AddedMeToContacts#initialize` to accept an optional originating scene parameter (`scene=nil`), falling back to `Scene_Main.new` upon exit.
- In `action_for("friend")` in `src/eapi/notificationgroups.rb`, passed `Scene_Main.new` and `return_to_main: true` to `insert_scene`, aligning contact addition notifications with existing blog and birthday notification flows.