### PR TITLE
Move Add to dictionary below the spelling suggestions

### DIFF
--- a/src/ui/controls/edit_box.rb
+++ b/src/ui/controls/edit_box.rb
@@ -669,7 +669,7 @@ def espellcheck
       options.push(opt)
     end
     label=phr+" "+letphr+": "+frg
-    lst = ListBox.new([p_("EAPI_Form", "Ignore"), p_("EAPI_Form", "Add to dictionary")]+options+[p_("EAPI_Form", "Use custom text")], header: label)
+    lst = ListBox.new([p_("EAPI_Form", "Ignore")]+options+[p_("EAPI_Form", "Add to dictionary"), p_("EAPI_Form", "Use custom text")], header: label)
 edt = EditBox.new(label, type: 0, text: phr)
 lst.on(:move) {
 for i in 0...errors.size
@@ -698,13 +698,13 @@ for i in 0...errors.size
   for i in 0...errors.size
     l=form.fields[1+i*2]
     idx=l.index
-    if idx==1
+    if idx==l.options.size-2
       word=(@text||"")[errors[i].index, errors[i].length]||""
       added+=1 if dictionary_add_dialog(word)
-    elsif idx>1
+    elsif idx>0
       corr=""
       if idx<l.options.size-1
-      corr=errors[i].suggestions[idx-2]
+      corr=errors[i].suggestions[idx-1]
     else
       corr=form.fields[1+i*2+1].text
       end


### PR DESCRIPTION
## What changed

Follow-up to #102. In the spell check dialog (Ctrl+Shift+S), "Add to dictionary"
was the second option in each error list, sitting above every correction
suggestion:

```
Ignore
Add to dictionary
alpha
beta
Use custom text
```

It now sits below the suggestions, right before "Use custom text":

```
Ignore
alpha
beta
Add to dictionary
Use custom text
```

The branch that dispatches the selection is indexed from the end of the list
(`idx==l.options.size-2`) rather than from a fixed position, so it holds for any
number of suggestions, including none.

## Why

Correcting a misspelling is the common case; teaching the checker a new word is
the exception. With the dictionary entry placed second, every trip to a
suggestion meant arrowing past an action that modifies persistent configuration.
Keeping the destructive-ish option out of the path to the frequent one also
matches where the other non-correction option ("Use custom text") already lives.

## User impact

Suggestions are reached one keystroke sooner and the two non-correction actions
are now grouped together at the bottom of the list. No change to the dictionary
feature itself, its storage format, or its dialog.

## Validation

- `ruby -c` on src/ui/controls/edit_box.rb: Syntax OK.
- Ad-hoc logic harness (Elten has no test suite), 23/23. The harness reads the
  real edit_box.rb, extracts the actual option-list expression and the actual
  `if`/`elsif` conditions from the source, then evaluates them — it holds no
  copy of the logic, so a wrong condition in the file fails it. Covers 0, 1 and
  3 suggestions (the 0 case matters, as the dictionary entry then follows
  "Ignore" directly), asserts the resolved action for every index, and guards
  that the edit box visibility hook is still keyed to the last index.
- Live tested on Windows + NVDA: option order as listed above, picking a
  suggestion replaces the word, and "Add to dictionary" still opens the add
  dialog.
