### PR TITLE
Allow restarting from developer to normal mode

### DIFF
--- a/src/eapi/core/runtime.rb
+++ b/src/eapi/core/runtime.rb
@@ -125,6 +125,28 @@ end
       EltenSystemHelpers.command_line_join(parts)
     end
 
+    def restart_to_normal_mode
+      command = normal_restart_command
+      if command.to_s == ""
+        Log.error("Normal restart failed: empty restart command")
+        return false
+      end
+      Log.info("Restarting Elten in normal mode: #{command}")
+      $exit_runproc = command
+      $exit_runproc_path = Dir.pwd
+      $exit = true
+      $scene = nil
+      true
+    rescue Exception => e
+      Log.error("Normal restart failed: #{e.class}: #{e.message}")
+      false
+    end
+
+    def normal_restart_command
+      parts = restart_command_parts.reject { |part| EltenBoot::DEVELOPER_FLAGS.include?(part.to_s.downcase) }
+      EltenSystemHelpers.command_line_join(parts)
+    end
+
     def restart_command_parts
       parts = original_process_arguments
       if parts.size > 0

--- a/src/eapi/mainmenu.rb
+++ b/src/eapi/mainmenu.rb
@@ -176,6 +176,12 @@ module GlobalMenu
     }
     end
     if developer_mode?
+    m.option(p_("MainMenu", "Restart in &normal mode")) {
+                                  play_sound("logout")
+              if !restart_to_normal_mode
+                alert(p_("MainMenu", "Cannot restart in normal mode."))
+              end
+    }
     m.option(p_("MainMenu", "Restart in de&bug mode")) {
                     play_sound("logout")
               $DEBUG=true

--- a/src/eapi/mainmenu.rb
+++ b/src/eapi/mainmenu.rb
@@ -176,17 +176,17 @@ module GlobalMenu
     }
     end
     if developer_mode?
-    m.option(p_("MainMenu", "Restart in &normal mode")) {
-                                  play_sound("logout")
-              if !restart_to_normal_mode
-                alert(p_("MainMenu", "Cannot restart in normal mode."))
-              end
-    }
     m.option(p_("MainMenu", "Restart in de&bug mode")) {
                     play_sound("logout")
               $DEBUG=true
               $restart=true
               $scene=Scene_Loading.new
+    }
+    m.option(p_("MainMenu", "Restart in &normal mode")) {
+                                  play_sound("logout")
+              if !restart_to_normal_mode
+                alert(p_("MainMenu", "Cannot restart in normal mode."))
+              end
     }
     end
     }


### PR DESCRIPTION
Adds a Restart in normal mode option at the end of the Quit menu when Elten is running in developer mode. The restart launches a new process with all recognised developer-mode flags removed while preserving the other original launch arguments.

The transition to normal mode cannot be verified with a contributor build because unstamped launchers always force developer mode. Command generation, developer-flag filtering and the Windows x64 build were verified.

Forum thread: https://elten.link/pl/forum/thread/27929