### PR TITLE
Show OK instead of Cancel for forum message of the day

### DIFF
--- a/src/scenes/forum.rb
+++ b/src/scenes/forum.rb
@@ -1027,7 +1027,7 @@ motd = groupmotd(group)
       fields=[
             EditBox.new((p_("Forum", "Message of the day of group %{groupname}")%{:groupname=>group.name}), type: ((group.role==2)?(EditBox::Flags::MultiLine):(EditBox::Flags::MultiLine|EditBox::Flags::ReadOnly)), text: motd),
             Button.new(_("Save")),
-            Button.new(_("Cancel"))
+            Button.new((group.role==2 && editable!=false)?_("Cancel"):_("OK"))
             ]
             fields[1]=nil if group.role!=2 or editable==false
             form=Form.new(fields)


### PR DESCRIPTION
The forum message of the day now shows OK instead of Cancel when it is displayed in read-only mode. Save and Cancel remain unchanged when a moderator opens the message for editing.

Forum thread: https://elten.link/pl/forum/thread/27854