### PR TITLE
Fix Escape navigation in server program browser

### DIFF
--- a/src/scenes/programs.rb
+++ b/src/scenes/programs.rb
@@ -345,6 +345,7 @@ when 1
              return
            end
            sel.focus
+           loop_update
          end
          break if key_pressed?(:key_escape)
        end


### PR DESCRIPTION
Pressing Escape in an author's program list now returns to the server program authors list instead of closing the server program browser.\n\nForum thread: https://elten.link/pl/forum/thread/27922