### PR TITLE
Unify calendar and task management shortcuts

### DIFF
--- a/src/scenes/calendar.rb
+++ b/src/scenes/calendar.rb
@@ -343,7 +343,7 @@ class Scene_Calendar
       end
     end
     if !preview_mode?
-      menu.option(p_("Calendar", "Calendar management"), nil, "c") do
+      menu.option(p_("Calendar", "Calendar management"), nil, "m") do
         $scene = Scene_Calendar_Management.new(@filter_calendar_id, @grid.date)
       end
     end


### PR DESCRIPTION
Changes the Calendar management shortcut from Ctrl+C to Ctrl+M, matching the shortcut used for task management.\n\nForum thread: https://elten.link/pl/forum/thread/27842