### PR TITLE
Keep current forum group after refresh

### DIFF
--- a/src/scenes/forum.rb
+++ b/src/scenes/forum.rb
@@ -2059,9 +2059,10 @@ break
     end
     sortermenu(1, @group, menu)
     menu.option(_("Refresh"), nil, "r") {
+      @frmsetid=@sforums[@frmsel.index].id if @sforums.size>0
 @@lastCacheIdent=nil
     getcache
-      main
+      forumsload(@group)
     }
   end
 


### PR DESCRIPTION
Refreshing the forum list now keeps the user in the current group and restores the selected forum instead of returning to the groups list.\n\nForum thread: https://elten.link/pl/forum/thread/27743