### PR TITLE
Add a dictionary manager to browse, edit and delete spell checker entries

### DIFF
--- a/filelist
+++ b/filelist
@@ -79,6 +79,7 @@ src/eapi/conference.rb
 src/scenes/account.rb
 src/scenes/keyboardshortcuts.rb
 src/scenes/settings.rb
+src/scenes/spellcheckdictionary.rb
 src/scenes/clock.rb
 src/scenes/programs.rb
 src/scenes/palantiri.rb
@@ -150,6 +151,7 @@ src/platforms/windows/eapi/sapi.rb :windows
 src/platforms/windows/eapi/spellcheck.rb :windows
 src/platforms/osx/eapi/spellcheck.rb :osx
 src/platforms/linux/eapi/spellcheck.rb :linux
+src/eapi/spellcheckdictionary.rb
 src/platforms/osx/eapi/childprocess.rb :osx
 src/platforms/linux/eapi/childprocess.rb :linux
 src/eapi/external.rb

--- a/src/eapi/spellcheckdictionary.rb
+++ b/src/eapi/spellcheckdictionary.rb
@@ -1,0 +1,144 @@
+# A part of Elten - EltenLink / Elten Network desktop client.
+# Copyright (C) 2014-2026 Dawid Pieper
+# Elten is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 3. 
+# Elten is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details. 
+# You should have received a copy of the GNU General Public License along with Elten. If not, see <https://www.gnu.org/licenses/>. 
+
+module EltenAPI
+  module SpellCheckDictionary
+    KEY = "SpellCheckCustomWords"
+    LEGACY_REGEXP_KEY = "SpellCheckCustomRegexps"
+    TYPES = ["w", "a", "r"].freeze
+
+    class Entry
+      attr_reader :pattern, :type, :case_sensitive
+
+      def initialize(pattern, type, case_sensitive)
+        @pattern = pattern.to_s
+        @type = TYPES.include?(type.to_s) ? type.to_s : "w"
+        @case_sensitive = case_sensitive == true
+      end
+
+      def match_type
+        TYPES.index(@type)
+      end
+
+      def serialize
+        (@case_sensitive ? "0" : "1") + @type + "|" + @pattern
+      end
+
+      def type_label
+        case @type
+        when "a" then p_("SpellCheckDictionary", "Match anywhere")
+        when "r" then p_("SpellCheckDictionary", "Regular expression")
+        else p_("SpellCheckDictionary", "Whole word")
+        end
+      end
+
+      def case_label
+        @case_sensitive ? p_("SpellCheckDictionary", "Yes") : p_("SpellCheckDictionary", "No")
+      end
+
+      def matches?(word)
+        return false if @pattern == ""
+        case @type
+        when "a"
+          @case_sensitive ? word.include?(@pattern) : word.downcase.include?(@pattern.downcase)
+        when "r"
+          begin
+            (@case_sensitive ? Regexp.new(@pattern) : Regexp.new(@pattern, Regexp::IGNORECASE)).match?(word)
+          rescue Exception
+            false
+          end
+        else
+          @case_sensitive ? @pattern == word : @pattern.casecmp?(word)
+        end
+      end
+    end
+
+    class << self
+      def entries
+        LocalConfig[KEY, [], type: :array_of_strings].map { |entry| parse(entry, "w") } +
+          LocalConfig[LEGACY_REGEXP_KEY, [], type: :array_of_strings].map { |entry| parse(entry, "r") }
+      end
+
+      def parse(entry, default_type = "w")
+        entry = entry.to_s
+        if entry =~ /\A([01])([war])\|(.*)\z/m
+          Entry.new($3, $2, $1 == "0")
+        elsif entry =~ /\A([01])\|(.*)\z/m
+          Entry.new($2, default_type, $1 == "0")
+        else
+          Entry.new(entry, default_type, false)
+        end
+      end
+
+      def add(pattern, match_type: 0, case_sensitive: false)
+        entry = build(pattern, match_type, case_sensitive)
+        return entry if entry.is_a?(Symbol)
+        return :duplicate if duplicate?(entry.serialize)
+        LocalConfig[KEY] = LocalConfig[KEY, [], type: :array_of_strings].push(entry.serialize)
+        :added
+      end
+
+      def replace(index, pattern, match_type: 0, case_sensitive: false)
+        entry = build(pattern, match_type, case_sensitive)
+        return entry if entry.is_a?(Symbol)
+        index = index.to_i
+        key, position = locate(index)
+        return :missing if key == nil
+        list = LocalConfig[key, [], type: :array_of_strings]
+        return :saved if parse(list[position], key == KEY ? "w" : "r").serialize == entry.serialize
+        return :duplicate if duplicate?(entry.serialize, index)
+        list[position] = entry.serialize
+        LocalConfig[key] = list
+        :saved
+      end
+
+      def delete(index)
+        key, position = locate(index)
+        return false if key == nil
+        list = LocalConfig[key, [], type: :array_of_strings]
+        list.delete_at(position)
+        LocalConfig[key] = list
+        true
+      end
+
+      def match?(word)
+        word = word.to_s
+        return false if word == ""
+        entries.any? { |entry| entry.matches?(word) }
+      end
+
+      private
+
+      def locate(index)
+        index = index.to_i
+        return [nil, nil] if index < 0
+        primary = LocalConfig[KEY, [], type: :array_of_strings].size
+        return [KEY, index] if index < primary
+        index -= primary
+        index < LocalConfig[LEGACY_REGEXP_KEY, [], type: :array_of_strings].size ? [LEGACY_REGEXP_KEY, index] : [nil, nil]
+      end
+
+      def duplicate?(serialized, except = nil)
+        entries.each_with_index.any? { |entry, i| entry.serialize == serialized && i != except }
+      end
+
+      def build(pattern, match_type, case_sensitive)
+        type = TYPES[match_type.to_i] || "w"
+        pattern = pattern.to_s
+        pattern = pattern.strip if type != "r"
+        return :empty if pattern == ""
+        if type == "r"
+          begin
+            Regexp.new(pattern)
+          rescue Exception
+            return :invalid
+          end
+        end
+        Entry.new(pattern, type, case_sensitive == true)
+      end
+    end
+  end
+end

--- a/src/scenes/settings.rb
+++ b/src/scenes/settings.rb
@@ -355,6 +355,7 @@ def make_window
         make_setting(p_("Settings", "Speech pitch"), (0..100).to_a.reverse.map{|x|x.to_s+"%"}, "Voice", "Pitch", (0..100).to_a.reverse)
         make_setting(p_("Settings", "Enable braille output"), :bool, "Interface", "EnableBraille") if SpeechOutput.list.any?{|output| output.braille_supported?}
         make_setting(p_("Settings", "Use a voice dictionary when processing characters (requires the NVDA add-on when using NVDA for speech output)"), :bool, "Voice", "UseVoiceDictionary")
+        make_setting(p_("Settings", "Manage the spell check dictionary"), :custom, Proc.new{insert_scene(Scene_SpellCheckDictionary.new)})
                         make_setting(p_("Settings", "Typing echo"), [p_("Settings", "Characters"),p_("Settings", "Words"),p_("Settings", "Characters and words"),p_("Settings", "None")], "Interface", "TypingEcho", ["characters", "words", "characters_and_words", "none"])
         on_load {
         voice_output=Proc.new {

--- a/src/scenes/spellcheckdictionary.rb
+++ b/src/scenes/spellcheckdictionary.rb
@@ -1,0 +1,117 @@
+# A part of Elten - EltenLink / Elten Network desktop client.
+# Copyright (C) 2014-2026 Dawid Pieper
+# Elten is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 3. 
+# Elten is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details. 
+# You should have received a copy of the GNU General Public License along with Elten. If not, see <https://www.gnu.org/licenses/>. 
+
+class Scene_SpellCheckDictionary
+  def main
+    @entries=SpellCheckDictionary.entries
+    @field=[]
+    @field[0]=TableBox.new([p_("SpellCheckDictionary", "Pattern"), p_("SpellCheckDictionary", "Match type"), p_("SpellCheckDictionary", "Case sensitive")], rows, header: p_("SpellCheckDictionary", "Dictionary entries"), quiet: false, empty_label: p_("SpellCheckDictionary", "The dictionary is empty"))
+    @field[1]=Button.new(p_("SpellCheckDictionary", "Add"))
+    @field[2]=Button.new(p_("SpellCheckDictionary", "Edit"))
+    @field[3]=Button.new(p_("SpellCheckDictionary", "Delete"))
+    @field[4]=Button.new(_("Close"))
+    @form=Form.new(@field)
+    @form.bind_context{|menu|context(menu)}
+    toggle_buttons
+    loop do
+      loop_update
+      @form.update
+      if key_pressed?(:key_escape) or @field[4].pressed?
+        $scene=Scene_Main.new
+        break
+      end
+      add_entry if @field[1].pressed?
+      edit_entry(@field[0].index) if (@form.index==0 and @field[0].selected?) or @field[2].pressed?
+      delete_entry(@field[0].index) if @field[3].pressed?
+      break if $scene!=self
+    end
+  end
+  def context(menu)
+    menu.option(p_("SpellCheckDictionary", "Add entry"), nil, "n") {add_entry}
+    if @entries.size>0
+      menu.option(p_("SpellCheckDictionary", "Edit entry"), nil, "e") {edit_entry(@field[0].index)}
+      menu.option(p_("SpellCheckDictionary", "Delete entry"), nil, :del) {delete_entry(@field[0].index)}
+    end
+  end
+  def add_entry
+    refresh if entry_dialog
+    focus_list
+  end
+  def edit_entry(index)
+    return if index<0 or @entries[index]==nil
+    refresh if entry_dialog(@entries[index], index)
+    focus_list
+  end
+  def delete_entry(index)
+    return if index<0
+    entry=@entries[index]
+    return if entry==nil
+    if confirm(p_("SpellCheckDictionary", "Are you sure you want to delete this entry?")+"\r\n"+entry.pattern) and SpellCheckDictionary.delete(index)
+      refresh
+      play_sound("editbox_delete")
+    end
+    focus_list
+  end
+  def entry_dialog(entry=nil, index=nil)
+    saved=false
+    begin
+      dialog_open
+      loop_update
+      dform=Form.new([
+        dpat=EditBox.new(p_("SpellCheckDictionary", "Pattern"), type: 0, text: (entry!=nil) ? entry.pattern : "", quiet: true),
+        dtype=ListBox.new([p_("SpellCheckDictionary", "Whole word"), p_("SpellCheckDictionary", "Match anywhere"), p_("SpellCheckDictionary", "Regular expression")], header: p_("SpellCheckDictionary", "Match type"), index: (entry!=nil) ? entry.match_type : 0),
+        dcase=CheckBox.new(p_("SpellCheckDictionary", "Case sensitive"), checked: (entry!=nil) ? entry.case_sensitive : false),
+        btn_save=Button.new(_("Save")),
+        btn_cancel=Button.new(_("Cancel"))
+      ], index: 0, silent: false, quiet: true)
+      dform.cancel_button=btn_cancel
+      btn_cancel.on(:press) {dform.resume}
+      btn_save.on(:press) {
+        result=(index!=nil) ? SpellCheckDictionary.replace(index, dpat.text, match_type: dtype.index, case_sensitive: dcase.value) : SpellCheckDictionary.add(dpat.text, match_type: dtype.index, case_sensitive: dcase.value)
+        case result
+        when :added, :saved
+          saved=true
+          dform.resume
+        when :duplicate
+          alert(p_("SpellCheckDictionary", "This entry is already in the dictionary."))
+        when :invalid
+          alert(p_("SpellCheckDictionary", "Invalid regular expression."))
+        when :missing
+          alert(p_("SpellCheckDictionary", "This entry is no longer in the dictionary."))
+          dform.resume
+        when :empty
+          alert(p_("SpellCheckDictionary", "Please enter a pattern."))
+        end
+      }
+      dform.accept_button=btn_save
+      dform.wait
+    ensure
+      dialog_close
+      loop_update
+    end
+    saved
+  end
+  def focus_list
+    @form.index=0
+    @field[0].focus
+  end
+  def rows
+    @entries.map{|entry|[entry.pattern, entry.type_label, entry.case_label]}
+  end
+  def toggle_buttons
+    [2, 3].each{|i|(@entries.size>0) ? @form.show(i) : @form.hide(i)}
+  end
+  def refresh
+    @entries=SpellCheckDictionary.entries
+    index=@field[0].index
+    index=@entries.size-1 if index>=@entries.size
+    index=0 if index<0
+    @field[0].rows=rows
+    @field[0].reload
+    @field[0].index=index
+    toggle_buttons
+  end
+end

--- a/src/ui/controls/edit_box.rb
+++ b/src/ui/controls/edit_box.rb
@@ -644,7 +644,7 @@ def espellcheck
   form.fields[1...-2]=[]
   form.show_all
   errors=SpellCheck.check(langs[lst_languages.index], @text)
-  errors=errors.reject{|e|dictionary_match?(splt[e.index...(e.index+e.length)])}
+  errors=errors.reject{|e|SpellCheckDictionary.match?(splt[e.index...(e.index+e.length)])}
   for error in errors
         phr=splt[error.index...(error.index+error.length)]
         frgb=-1
@@ -746,7 +746,7 @@ def dictionary_add_dialog(word)
     dform.cancel_button=btn_cancel
     btn_cancel.on(:press) {dform.resume}
     btn_save.on(:press) {
-      case dictionary_add(dpat.text, match_type: dtype.index, case_sensitive: dcase.value)
+      case SpellCheckDictionary.add(dpat.text, match_type: dtype.index, case_sensitive: dcase.value)
       when :added
         result=true
         dform.resume
@@ -766,64 +766,6 @@ def dictionary_add_dialog(word)
   end
   result
   end
-def dictionary_parse(entry, default_type)
-  entry=entry.to_s
-  if entry=~/\A([01])([war])\|(.*)\z/m
-    [$1=="1", $2, $3]
-  elsif entry=~/\A([01])\|(.*)\z/m
-    [$1=="1", default_type, $2]
-  else
-    [true, default_type, entry]
-  end
-end
-def dictionary_add(pattern, match_type: 0, case_sensitive: false)
-  type=["w","a","r"][match_type]||"w"
-  pattern=pattern.to_s
-  pattern=pattern.strip unless type=="r"
-  return :empty if pattern==""
-  if type=="r"
-    begin
-      Regexp.new(pattern)
-    rescue Exception
-      return :invalid
-    end
-  end
-  ic=case_sensitive!=true
-  entry=(ic ? "1" : "0")+type+"|"+pattern
-  list=LocalConfig["SpellCheckCustomWords", [], type: :array_of_strings]
-  return :duplicate if list.include?(entry)
-  list.push(entry)
-  LocalConfig["SpellCheckCustomWords"]=list
-  :added
-end
-def dictionary_match_entry?(entry, default_type, word)
-  ic, type, val = dictionary_parse(entry, default_type)
-  return false if val==""
-  case type
-  when "a"
-    ic ? word.downcase.include?(val.downcase) : word.include?(val)
-  when "r"
-    begin
-      re = ic ? Regexp.new(val, Regexp::IGNORECASE) : Regexp.new(val)
-      re.match?(word)
-    rescue Exception
-      false
-    end
-  else
-    ic ? val.casecmp?(word) : val==word
-  end
-end
-def dictionary_match?(word)
-  word=word.to_s
-  return false if word==""
-  LocalConfig["SpellCheckCustomWords", [], type: :array_of_strings].each do |entry|
-    return true if dictionary_match_entry?(entry, "w", word)
-  end
-  LocalConfig["SpellCheckCustomRegexps", [], type: :array_of_strings].each do |entry|
-    return true if dictionary_match_entry?(entry, "r", word)
-  end
-  false
-end
 def copy
       Clipboard.text = get_check.gsub("\n","\r\n")
     alert(p_("EAPI_Form", "copied"), false)


### PR DESCRIPTION
## What changed

Adds a dictionary manager for the spell checker's custom dictionary, reachable from
**Settings → Voice → Manage custom dictionary**.

The manager lists every entry in a table (pattern, match type, case sensitivity) and
allows adding, editing and deleting entries. Edit and Delete are hidden while the
dictionary is empty, so the form never exposes buttons that cannot act on anything.

The dictionary logic previously living in `edit_box.rb` (`dictionary_parse`,
`dictionary_add`, `dictionary_match_entry?`, `dictionary_match?`) moves into a new
`SpellCheckDictionary` module in `src/eapi/`, so the manager and the spell checker
share a single implementation instead of duplicating the parsing and matching rules.
The reader concatenates both the primary key and the legacy regexp key, and every
writer maps a list index back to the correct underlying key.

## Why

The custom dictionary could only be extended from the spell checker prompt with
Ctrl+Shift+S, and only while a spelling error was actually detected. Once an entry was
added there was no way to review it, fix a typo in it, or remove it — a wrong entry
silently suppressed spell checking for that word forever, with no way to find out why.

## User impact

- Entries can be reviewed, corrected and removed instead of being write-once.
- Entries can be added without waiting for a spelling error to appear.
- Existing dictionaries keep working untouched: both the current storage format and the
  legacy regexp key are read and written exactly as before, including the case
  sensitivity flag encoding.
- Saving an entry without changing it is treated as a no-op rather than reported as a
  duplicate, so an entry that happens to exist in both storage keys stays editable.
- Deletion feedback (sound and refresh) is only given when an entry was really removed,
  which matters on a screen reader where the sound is the only confirmation.

## Validation

Elten has no test suite, so verification was done with ad-hoc harnesses driving the real
module (not a reimplementation of its logic) plus a manual pass in the running client.

Automated, against the actual source files:

- Parsing and serialisation round-trip for all three stored prefix formats, including
  legacy entries with no prefix and the inverted case sensitivity flag.
- Index mapping across the primary/legacy boundary for add, edit and delete, including
  the first and last entry of each key and non-integer indices.
- Duplicate detection: real duplicates are rejected, an unchanged re-save is accepted,
  and renaming an entry is not blocked by its own previous value.
- Empty dictionary, deleting the last remaining entry, and focus/selection state after
  each refresh.
- Match semantics compared against the pre-change implementation to confirm whole word,
  substring and regexp behaviour, and regexp compilation failures, are unchanged.
- The setting entry is wired into the Voice category, and the scene loads correctly
  given the order used by `filelist`.
- New user-facing strings fall back to English when no translation exists.

Manual, in the running client with a screen reader: adding, editing an entry both with
and without changing it, deleting an entry, deleting the last entry, and navigating the
manager with an empty dictionary.

`locale/elten.pot` is intentionally not regenerated here, as it is maintained in separate
translation template commits.
