### PR TITLE
Return to main window after completing program updates from notification

### DIFF
--- a/src/scenes/programs.rb
+++ b/src/scenes/programs.rb
@@ -1,4 +1,4 @@
-﻿# A part of Elten - EltenLink / Elten Network desktop client.
+# A part of Elten - EltenLink / Elten Network desktop client.
 # Copyright (C) 2014-2026 Dawid Pieper
 # Elten is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 3. 
 # Elten is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details. 
@@ -28,7 +28,8 @@ class Scene_Programs
      if @initial_action==:updates
        @initial_action=nil
        check_updates
-       return main if @refresh
+       $scene=Scene_Main.new if $scene==self
+       return
      end
      loop do
        loop_update


### PR DESCRIPTION
### Summary
Fixes an issue where activating the program updates notification from the main window leaves the user stranded in the installed programs list (`Scene_Programs`) after updates finish.

### Behavior
- When `Scene_Programs` is launched with `@initial_action == :updates` (from the main window's update notification):
  - Running `check_updates` now returns directly to `Scene_Main` (`$scene = Scene_Main.new if $scene == self; return`), whether updates were installed, cancelled by the user, or no updates were available.
- When `check_updates` is invoked from within `Scene_Programs` (via context menu in the installed programs manager), it preserves the existing behavior: the table reloads so the user remains on the programs list with updated versions visible.

Addresses forum thread #27939 (*[Zmiana] [Interfejs] Po zaktualizowaniu jakiegoś programu, otwiera się lista zainstalowanych*).
