### PR TITLE
Report actual NVDA speech state so alerts are not cut off

### DIFF
--- a/nvda/elten/globalPlugins/elten.py
+++ b/nvda/elten/globalPlugins/elten.py
@@ -29,6 +29,9 @@ import re
 stopThreads=False
 eltenindex=None
 eltenindexid=None
+eltenspeaking=False
+eltengeneration=0
+eltencancelarmed=True
 
 if is_python_3_or_above:
 	class EltenIndexCallback(speech.commands.BaseCallbackCommand):
@@ -49,6 +52,37 @@ if is_python_3_or_above:
 	class EltenEmptyCallback(speech.commands.BaseCallbackCommand):
 		def run(self): pass
 		def __repr__(self): return "EltenEmptyCallback()"
+
+	class EltenDoneCallback(speech.commands.BaseCallbackCommand):
+		def __init__(self, gen):
+			super().__init__()
+			self.gen = gen
+		def run(self):
+			global eltenspeaking
+			if self.gen != eltengeneration: return
+			eltenspeaking = False
+		def __repr__(self): return "EltenDoneCallback()"
+
+	def eltenSpeechCanceled(*args, **kwargs):
+		global eltenspeaking
+		if eltencancelarmed == False: return
+		eltenspeaking = False
+
+	def eltencancelquiet():
+		global eltencancelarmed
+		eltencancelarmed = False
+		try: speech.cancelSpeech()
+		finally: eltencancelarmed = True
+
+	try:
+		from speech import extensions as eltenSpeechExtensions
+		global eltencancelhandler
+		eltencancelhandler = eltenSpeechCanceled
+		for eltencancelpoint in ("speechCanceled", "pre_speechCanceled"):
+			eltenpoint = getattr(eltenSpeechExtensions, eltencancelpoint, None)
+			if eltenpoint != None: eltenpoint.register(eltencancelhandler)
+	except Exception:
+		pass
 
 eltenmod=None
 eltenbraille = braille.BrailleBuffer(braille.handler)
@@ -232,6 +266,8 @@ def elten_command(ac):
 	global eltenindex
 	global eltenindexid
 	global eltenqueue
+	global eltenspeaking
+	global eltengeneration
 	try:
 		if(('ac' in ac)==False): return {}
 		if(ac['ac']=="speak"):
@@ -239,7 +275,13 @@ def elten_command(ac):
 			eltenindexid=None
 			text=""
 			if('text' in ac): text=ac['text']
-			if(speech.isBlank(text)==False): queueHandler.queueFunction(queueHandler.eventQueue,speech.speakText,text)
+			if(speech.isBlank(text)==False):
+				if is_python_3_or_above:
+					eltengeneration+=1
+					eltenspeaking=True
+					queueHandler.queueFunction(queueHandler.eventQueue,speech.speak,[text, EltenDoneCallback(eltengeneration)])
+				else:
+					queueHandler.queueFunction(queueHandler.eventQueue,speech.speakText,text)
 		if(ac['ac']=="speakspelling"):
 			eltenindex=None
 			eltenindexid=None
@@ -270,12 +312,20 @@ def elten_command(ac):
 				v.append(texts[i].replace("\n", " "))
 				text_added = True
 			log.info(v.__repr__())
-			queueHandler.queueFunction(queueHandler.eventQueue,speech.cancelSpeech)
+			if is_python_3_or_above and len(v)>0:
+				eltengeneration+=1
+				eltenspeaking=True
+				v.append(EltenDoneCallback(eltengeneration))
+			queueHandler.queueFunction(queueHandler.eventQueue,eltencancelquiet)
 			queueHandler.queueFunction(queueHandler.eventQueue,speech.speak,v)
 		if(ac['ac']=='stop'):
-			queueHandler.queueFunction(queueHandler.eventQueue,speech.cancelSpeech)
+			eltengeneration+=1
+			queueHandler.queueFunction(queueHandler.eventQueue,eltencancelquiet)
 			eltenindex=None
 			eltenindexid=None
+			eltenspeaking=False
+		if(ac['ac']=='speaking'):
+			return {'speaking': eltenspeaking}
 		if(ac['ac']=='sleepmode'):
 			st=eltenmod.sleepMode
 			if('st' in ac): st=ac['st']
@@ -334,7 +384,7 @@ def elten_command(ac):
 			eltenbraille.update()
 			braille.handler.update()
 		if(ac['ac']=='getversion'):
-			return {'version': 44}
+			return {'version': 45}
 		if(ac['ac']=='getnvdaversion'):
 			return {'version': buildVersion.version}
 		if(ac['ac']=='getindex'):

--- a/src/eapi/speech.rb
+++ b/src/eapi/speech.rb
@@ -225,8 +225,9 @@ def speech_actived(ignoreaudio=false)
   
   # Waits for a speech to finish reading of the previous message
       def speech_wait
-        if !speech_output_nvda?
-    while speech_actived == true
+        if !speech_output_nvda? || speech_output.speaking_supported?
+          t=Time.now.to_f
+    while speech_actived == true && Time.now.to_f-t<30.0
 loop_update(false)
 end
 else

--- a/src/eapi/speechoutput.rb
+++ b/src/eapi/speechoutput.rb
@@ -200,6 +200,10 @@ class SpeechOutput
       false
     end
 
+    def speaking_supported?
+      false
+    end
+
     def stop
       1
     end

--- a/src/platforms/windows/eapi/nvda.rb
+++ b/src/platforms/windows/eapi/nvda.rb
@@ -236,6 +236,7 @@ elsif j['msgtype']==4
               @stopped=false
               @index=nil
             @indid=nil
+            @speaking=true if speaking_supported?
                                           #sleep(0.01)
       write({'ac'=>'speak', 'text'=>text},nil,true)!=nil
     end
@@ -279,6 +280,7 @@ end
       @stopped=false
       @index=nil
             @indid=nil
+            @speaking=true if speaking_supported?
               #sleep(0.01)
       write({'ac'=>'speakindexed', 'texts'=>texts, 'indexes'=>indexes, 'indid'=>indid}, nil, true)
       end
@@ -307,6 +309,21 @@ end
             version=a['version'] if a!=nil
             return version
           end
+
+    def speaking_supported?
+      return true if @speaking_supported==true
+      v=getversion
+      @speaking_supported = (v!=nil && v.to_i>=45)
+    end
+
+    def speaking?
+      return false if @stopped==true
+      return false if !speaking_supported?
+      return false if @speaking==false
+      a=write({'ac'=>'speaking'})
+      return false if a==nil
+      a['speaking']==true
+    end
           def getnvdaversion
             a=write({'ac'=>'getnvdaversion'})
             version=nil
@@ -345,6 +362,7 @@ end
             return if @stopped==true
             @index=nil
             @indid=nil
+            @speaking=false
             @stopped=true
                                                             write({'ac'=>'stop'},nil,true)!=nil
                                     end

--- a/src/scenes/loading.rb
+++ b/src/scenes/loading.rb
@@ -223,7 +223,7 @@ end
   else
       delay(1)
       end
-v=44
+v=45
 if nvda_running && defined?(NVDA) && (!NVDA.check || NVDA.getversion!=v)
   if !NVDA.check
   str=p_("Loading", "Elten has detected that you are using NVDA. To support some features of this screen reader, the Elten add-on for NVDA must be installed. Do you want to install it now?")


### PR DESCRIPTION
## What changed

The NVDA speech output now reports whether it is actually speaking, and `speech_wait` waits for that real state instead of returning immediately.

This needs both sides of the bridge, so the change spans the client and the bundled NVDA add-on:

**Add-on (`nvda/elten/globalPlugins/elten.py`)**

- Each utterance submitted through `speakindexed` carries a done callback, so the add-on knows when NVDA has finished speaking it.
- A new `speaking` action answers that state on request.
- Reported version goes from 44 to 45, and `src/scenes/loading.rb` expects 45, so an existing installation is offered the update on the next start through the usual prompt. The add-on package itself is built from this directory by the asset generator, so there is no binary to commit.

**Client**

- `NVDA#speaking?` polls the new action. `speaking_supported?` gates it on add-on version 45, so an older add-on keeps the previous behaviour instead of hanging.
- `speech_wait` pumps the main loop until speech ends, with a 30 second watchdog so a lost callback can never freeze the client.

Cancellation is generation-tagged. A done callback belonging to a superseded utterance no longer clears the flag of the current one, and the add-on's own interrupting cancel no longer reports the fresh utterance as finished. A genuine user interrupt (Control) still cancels normally.

## Why

`alert` announced a message and returned immediately, so the next `speak` truncated it. Users heard only the first fraction of a second of confirmations and error messages.

This follows the approach merged for macOS in #109: ask the speech backend for its real state rather than estimating it. The previous revision of this PR guarded `speech_stop` with a pending flag, which is the same strategy that was closed in #123; that guard has been removed entirely and no caller passes a `force` argument anymore.

## User impact

Alerts are announced in full on NVDA. Users on add-on 44 are unaffected until they accept the update prompt: `speaking_supported?` returns false and the previous non-blocking path is used.

## Validation

- Verified live on Windows with NVDA 2026.1 and the add-on from this branch: the confirmation that was previously cut off is now read to the end, and Control still silences speech.
- Diagnostic logging in `speech_wait` confirmed the wait loop runs to completion (12 frames / 0.565 s) where it previously exited after 0 frames / 0.053 s. That instrumentation was removed before this commit.
- Ad-hoc harness (35 checks) run against the committed tree, executing the real `speech_wait` body and the real add-on callback block: waits for the true end of speech, never blocks on an old add-on, falls back correctly for non-NVDA output, releases on the 30 s watchdog, and ignores stale generation callbacks.
- `ruby -c` clean on all changed files.
