### PR TITLE
Default forum search to all fields when none are selected

### DIFF
--- a/src/scenes/forum.rb
+++ b/src/scenes/forum.rb
@@ -1650,7 +1650,6 @@ loop do
     btn_cancel = Button.new(_("Cancel"))
     ], index: 0, silent: false, quiet: true)
     form.hide(lst_threadin) if obj!=nil
-        lst_phrasein.selected[0]=true
     lst_threadin.selected[0]=true
     lst_threadin.selected[1]=true
 chk_transcriptions.on(:change) {
@@ -1667,6 +1666,7 @@ chk_transcriptions.checked=false if !requires_premiumpackage("courier")
             result.phrase_in.push(:name) if lst_phrasein.selected[0]
                   result.phrase_in.push(:content) if lst_phrasein.selected[1]
         result.phrase_in.push(:author) if lst_phrasein.selected[2]
+        result.phrase_in.push(:name, :content, :author) if result.phrase_in.empty?
                   if obj==nil
                   result.thread_in.push(:joined)  if lst_threadin.selected[0]
           result.thread_in.push(:recommended) if lst_threadin.selected[1]


### PR DESCRIPTION
### Summary
Improves the forum search experience by clearing pre-selected search fields by default and automatically searching across all fields (titles, content, authors) when no specific filters are checked.

### Problem Description
Previously, opening the forum search dialog defaulted to checking only `Titles` (`lst_phrasein.selected[0] = true`). Users intending to search through post content or across the entire forum had to navigate through the form to uncheck `Titles` and check `Content`. This added unnecessary friction for everyday forum searches.

### Changes
1. **Uncheck search fields by default**: Removed `lst_phrasein.selected[0] = true` so that no fields are pre-selected when opening the search dialog.
2. **Default fallback to all fields**: In `btn_search.on(:press)` (and when submitting via Enter in the search edit box), if `result.phrase_in` is empty, it automatically defaults to `[:name, :content, :author]`.
3. **Preserve selective filtering**: When a user explicitly selects one or more specific criteria (such as only Content or Authors), only the chosen fields are searched as before.

### Verification
- Verified syntax cleanly with `RubyVM::InstructionSequence.compile_file`.
- Verified with unit tests that empty selection defaults to searching titles, content, and authors.
- Verified that explicit selections restrict the search scope exclusively to the chosen fields.