### PR TITLE
Reorganize the Programs menu

### DIFF
--- a/src/eapi/mainmenu.rb
+++ b/src/eapi/mainmenu.rb
@@ -91,11 +91,20 @@ module GlobalMenu
     }
     end
     @menu.submenu(p_("MainMenu", "&Programs")) {|m|
-    list=Programs.list
-    for prg in list
-      m.scene(prg.menu_label||prg.name||prg.to_s, prg) if !prg.hidden?
-      end
-    m.scene(p_("MainMenu", "Programs management"), Scene_Programs)
+    programs=Programs.list.filter_map do |program|
+      next if program.hidden?
+      [program.menu_label||program.name||program.to_s, program]
+    end
+    if programs.size>0
+      m.submenu(p_("MainMenu", "Installed &programs")) {|installed|
+      programs.each {|label, program| installed.scene(label, program)}
+      }
+    end
+    m.scene(p_("MainMenu", "&Manage installed programs"), Scene_Programs)
+    m.submenu(p_("MainMenu", "Install &new programs")) {|install|
+      install.scene(p_("MainMenu", "Install from &server"), Scene_Programs, :install_from_server)
+      install.scene(p_("MainMenu", "Install from &file"), Scene_Programs, :install_from_file)
+    }
     }
     @menu.submenu(p_("MainMenu", "&Tools")) {|m|
     m.scene(p_("MainMenu", "Program &settings"), Scene_Settings)

--- a/src/scenes/programs.rb
+++ b/src/scenes/programs.rb
@@ -20,11 +20,22 @@ class Scene_Programs
   def main
     @installed=Programs.local_entries
     @programs=[]
+    @refresh=false
+    if @initial_action==:install_from_server
+      @initial_action=nil
+      install_from_server
+      $scene=Scene_Main.new if $scene==self
+      return
+    elsif @initial_action==:install_from_file
+      @initial_action=nil
+      install_from_file
+      $scene=Scene_Main.new if $scene==self
+      return
+    end
     @all=@installed
     rows=@all.map{|program| installed_row(program)}
      @sel=TableBox.new([p_("Programs", "Name"), p_("Programs", "Version"), p_("Programs", "Installation"), p_("Programs", "Status")], rows, index: 0, header: p_("Programs", "Installed programs"), quiet: false)
      @sel.bind_context{|menu|context(menu)}
-     @refresh=false
      if @initial_action==:updates
        @initial_action=nil
        check_updates
@@ -50,7 +61,6 @@ end
        }
        program=@all[@sel.index]
        if program==nil
-         add_install_options(menu)
          return
        end
        menu.option(p_("Programs", "Details")) {
@@ -103,16 +113,6 @@ when 1
            end
          }
        end
-       add_install_options(menu)
-     end
-
-     def add_install_options(menu)
-       menu.option(p_("Programs", "Install new program from server"), nil, "i") {
-         install_from_server
-       }
-       menu.option(p_("Programs", "Install new program from file"), nil, "I") {
-         install_from_file
-       }
      end
 
      def installed_row(program)

--- a/src/scenes/welcome_wizard.rb
+++ b/src/scenes/welcome_wizard.rb
@@ -504,7 +504,7 @@ class Scene_WelcomeWizard
     add_info_page(
       :program_compatibility,
       p_("WelcomeWizard", "Programs from Elten 2.x"),
-      p_("WelcomeWizard", "Programs written for Elten 2.x cannot run in Elten 3.0 and are not carried over during the upgrade. Compatible versions of the official programs are available from Programs management in the Programs menu, and later in this wizard you will be offered a few of the most useful ones. When an installed program has an update available, Elten 3.0 lets you know through a notification.")
+      p_("WelcomeWizard", "Programs written for Elten 2.x cannot run in Elten 3.0 and are not carried over during the upgrade. Compatible versions of the official programs are available from Install new programs in the Programs menu, and later in this wizard you will be offered a few of the most useful ones. When an installed program has an update available, Elten 3.0 lets you know through a notification.")
     )
     add_info_page(
       :shared_notifications,
@@ -1033,7 +1033,7 @@ class Scene_WelcomeWizard
       status = if installed
         p_("WelcomeWizard", "This program is already installed. The wizard will not reinstall it.")
       elsif app == nil
-        p_("WelcomeWizard", "The server is not currently offering this program for your operating system. Nothing can be selected here; check Programs management again later.")
+        p_("WelcomeWizard", "The server is not currently offering this program for your operating system. Nothing can be selected here; check Install new programs again later.")
       else
         p_("WelcomeWizard", "Available version: %{version}. Author: %{author}. Download size: %{size}.") % {
           version: app.version.to_s,


### PR DESCRIPTION
Reorganizes the Programs menu into separate sections for launching, managing, and installing programs.

Installed programs are placed in an “Installed programs” submenu. Program management remains directly available from the Programs menu, while installation from the server or a local file is moved to a dedicated “Install new programs” submenu.

The program management screen no longer duplicates installation actions in its context menu. References in the welcome wizard are updated to match the new menu structure.

Tested in Elten 3.0.3 developer mode.