### PR TITLE
Avoid duplicate shutdown sounds when switching modes

### DIFF
--- a/src/eapi/mainmenu.rb
+++ b/src/eapi/mainmenu.rb
@@ -169,7 +169,6 @@ module GlobalMenu
     }
     if !developer_mode?
     m.option(p_("MainMenu", "Restart in de&veloper mode")) {
-                                  play_sound("logout")
               if !restart_to_developer_mode
                 alert(p_("MainMenu", "Cannot restart in developer mode."))
               end
@@ -183,7 +182,6 @@ module GlobalMenu
               $scene=Scene_Loading.new
     }
     m.option(p_("MainMenu", "Restart in &normal mode")) {
-                                  play_sound("logout")
               if !restart_to_normal_mode
                 alert(p_("MainMenu", "Cannot restart in normal mode."))
               end


### PR DESCRIPTION
Removes the redundant logout sound playback from the menu actions that restart Elten in developer or normal mode.

Both actions exit the current process, and the shared shutdown path already plays the logout sound. The explicit calls therefore caused the sound to play twice.

Tested in Elten 3.0.3 when switching from normal mode to developer mode.