### PR TITLE
Add sound theme review with instant keep action

### DIFF
--- a/src/scenes/sounds.rb
+++ b/src/scenes/sounds.rb
@@ -7,9 +7,10 @@
 require "fileutils"
 
 class Scene_Sounds
-  def initialize(file=nil)
+  def initialize(file=nil, on_keep: nil)
     @file=file
-        end
+    @on_keep=on_keep
+  end
   def main
     @theme=load_soundtheme(@file)
 @soundnames={
@@ -110,6 +111,7 @@ class Scene_Sounds
 'waiting' => p_("Sounds", "Waiting for an action to be completed"),
 'signal' => p_("Sounds", "Signal"),
 }
+    return (alert(_("Error")); @on_keep ? nil : $scene=Scene_SoundThemes.new) if @theme==nil && @file.to_s!=""
     if @file!=nil
       if @file!=""
         @name=@theme.name
@@ -142,11 +144,14 @@ class Scene_Sounds
     return $scene=Scene_Main.new if @snd.size==0
     h=p_("Sounds", "Sound guide; press Space to play")
     h=p_("Sounds", "Editing sound theme %{theme}")%{:theme=>@name} if @theme!=nil
+    h=p_("Sounds", "Previewing sound theme %{theme}; press Space to play")%{:theme=>@name} if @on_keep && @theme!=nil
+    @btn_keep = Button.new(p_("Sounds", "Keep")) if @on_keep.respond_to?(:call)
     @fields = [
     @sel=ListBox.new(@snd.map{|o| o.description}, header: h, index: 0, flags: ListBox::Flags::Silent),
     @btn_play = Button.new(p_("Sounds", "Play")),
     @btn_playorig = Button.new(p_("Sounds", "Play original sound")),
     @btn_stop = Button.new(p_("Sounds", "Stop")),
+    @btn_keep,
     @btn_extract = Button.new(p_("Sounds", "Extract")),
     @btn_change = Button.new(p_("Sounds", "Change")),
     @btn_rename = Button.new(p_("Sounds", "Change sound theme name")),
@@ -154,9 +159,11 @@ class Scene_Sounds
      @btn_export = Button.new(p_("Sounds", "Export")),
         @btn_upload = Button.new(p_("Sounds", "Upload to server")),
         @btn_close = Button.new(p_("Sounds", "Close"))
-    ]
+    ].compact
           a=nil
     @form=Form.new(@fields, index: 0, silent: false, quiet: true)
+    [@btn_extract, @btn_change, @btn_save, @btn_export, @btn_rename, @btn_upload].each { |b| @form.hide(b) } if @on_keep
+    @btn_keep.on(:press) { @on_keep.call; @form.hide(@btn_keep); @btn_close.focus } if @btn_keep
     if @theme==nil
       @form.hide(@btn_playorig)
       @form.hide(@btn_change)
@@ -191,6 +198,7 @@ class Scene_Sounds
     @btn_playorig.press
     end
     }
+    @sel.on(:key_enter) { @btn_play.press }
     @btn_stop.on(:press) {
     if a!=nil
                   a.close
@@ -243,10 +251,11 @@ save
     }
     @form.cancel_button = @btn_close
     @form.wait  
-              if @changed and @theme!=nil
+              if @changed and @theme!=nil and !@on_keep
                 confirm(p_("Sounds", "Do you want to save this sound theme?")) {save}
                 end
     a.close if a!=nil
+    return if @on_keep
     if @theme==nil
     $scene=Scene_Main.new
   else

--- a/src/scenes/soundthemes.rb
+++ b/src/scenes/soundthemes.rb
@@ -4,6 +4,8 @@
 # Elten is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details. 
 # You should have received a copy of the GNU General Public License along with Elten. If not, see <https://www.gnu.org/licenses/>. 
 
+require "fileutils"
+
 class Scene_SoundThemes
   def main
     @return = false
@@ -180,6 +182,27 @@ menu.option(p_("SoundThemes", "Download")) {
           sel.rows=sts
           sel.reload
           }
+}
+menu.option(p_("SoundThemes", "Review sound theme"), nil, "p") {
+  dest = EltenPath.join(Dirs.soundthemes, st.file.delete("/\\"))
+  temp = EltenPath.join(Dirs.temp, "preview_#{st.file.delete('/\\')}")
+  file = File.file?(dest) ? dest : temp
+  if file == dest || download_file(EltenLink::SoundThemes.download_url(st), temp, use_waiting: true, can_cancel: true, override: true)
+    kept = false
+    on_keep = (file == dest) ? true : proc {
+      FileUtils.mv(temp, dest, force: true)
+      @soundthemes.delete_if { |s| s.file && File.basename(s.file) == File.basename(st.file) }.push(st)
+      alert(_("Saved"))
+      kept = true
+    }
+    begin
+      Scene_Sounds.new(file, on_keep: on_keep).main
+    ensure
+      FileUtils.rm_f(temp) unless kept
+    end
+    (rfr.call; sel.rows = sts; sel.reload) if kept
+    sel.focus
+  end
 }
 if st.user==Session.name || Session.moderator==1
 menu.option(p_("SoundThemes", "Delete"), nil, :del) {


### PR DESCRIPTION
## Summary

This PR implements sound theme review functionality directly from the downloadable sound themes category menu, allowing users to preview sounds in a theme before installation and instantly keep it without having to redownload.

## Changes

- **Downloadable sound themes menu (`src/scenes/soundthemes.rb`)**:
  - Added "Review sound theme" option (shortcut: `p`) to the context menu in `stdownload_category`.
  - If the theme is not yet downloaded, downloads it to a temporary file in `Dirs.temp` with progress indication.
  - Passes an `on_keep` callback to `Scene_Sounds` that moves the file from `Dirs.temp` to `Dirs.soundthemes`, updates the sound themes registry, and alerts the user.
  - Ensures cleanup of the temporary file in `ensure` if the user cancels or exits without keeping.
  - If the theme is already installed, directly previews the existing local file.
  - Refreshes table rows upon keeping to immediately reflect the downloaded status.

- **Sounds scene (`src/scenes/sounds.rb`)**:
  - Added optional `on_keep` callback to `initialize`.
  - Added "Keep" button (`@btn_keep`) when previewing a downloadable theme (`@on_keep.respond_to?(:call)`).
  - Conditionally displays preview header indicating space key to play.
  - Hides non-preview editing buttons (`extract`, `change`, `rename`, `save`, `export`, `upload`).
  - Hitting `Enter` or `Space` plays the selected sound.
  - Clicking "Keep" invokes the callback, hides the button, and shifts focus to "Close".
  - Cleanly returns from the scene without resetting `$scene`.

## Guidelines & Verification
- Preserved `locale/` translation files untouched per contributing guidelines.
- Verified UTF-8 encoding without BOM.
- Verified syntax via `RubyVM::InstructionSequence.compile_file`.
- Tested in live Elten instance.