### PR TITLE
Prevent deletion of default sound theme regardless of list position

### DIFF
--- a/src/scenes/soundthemes.rb
+++ b/src/scenes/soundthemes.rb
@@ -70,13 +70,13 @@ stdownload
           menu.option(p_("SoundThemes", "New"), nil, "n") {
                         $scene=Scene_Sounds.new("")
           }
-          if @sel.index<@soundthemes.size-1
+          theme=@soundthemes[@sel.index]
+          if theme!=nil && theme.file!=nil && theme.file!=""
           menu.option(p_("SoundThemes", "Edit"), nil, "e") {
-                        $scene=Scene_Sounds.new(@soundthemes[@sel.index].file)
+                        $scene=Scene_Sounds.new(theme.file)
           }
           menu.option(p_("SoundThemes", "Delete"), nil, :del) {
-                          confirm(p_("SoundThemes", "Are you sure you want to delete the sound theme %{soundtheme}?")%{ :soundtheme => @soundthemes[@sel.index].name}) {
-                theme=@soundthemes[@sel.index]
+                          confirm(p_("SoundThemes", "Are you sure you want to delete the sound theme %{soundtheme}?")%{ :soundtheme => theme.name}) {
                 File.delete(theme.file)
                 if Configuration.soundtheme!=nil && File.basename(theme.file, ".elsnd")==Configuration.soundtheme
                   Configuration.soundtheme=nil


### PR DESCRIPTION
## Summary

This PR addresses an issue introduced after merging #132 (sorting the active sound theme to the top of the list).

Previously, `Scene_SoundThemes#context` checked `@sel.index < @soundthemes.size - 1` under the assumption that the built-in default theme was always at the bottom of the list. When the default theme is active, it is placed at index 0, causing:
1. The default theme (having `theme.file == nil`) to expose "Edit" and "Delete" options in its context menu.
2. The last sound theme in the list to lose its "Edit" and "Delete" options.

## Changes

- In `src/scenes/soundthemes.rb`:
  - Check whether `theme != nil && theme.file != nil && theme.file != ""` instead of checking list index.
  - Ensures the default theme (`theme.file == nil`) is never editable or deletable regardless of where it appears in the list.
  - Ensures all user-installed themes are always editable and deletable, even when active at index 0 or placed at the bottom.

## Guidelines & Verification
- No `locale/` files modified.
- Pure UTF-8 without BOM.
- Verified syntax via `RubyVM::InstructionSequence.compile_file`.
- Tested in live Elten client.