### PR TITLE
Move login greeting from account settings to application settings

### DIFF
--- a/src/eapi/core/configuration.rb
+++ b/src/eapi/core/configuration.rb
@@ -200,7 +200,9 @@ use_soundtheme(stheme)
                       Configuration.conferencesaudiobuffer = readconfig("Advanced", "ConferencesAudioBuffer", 0)
                       Configuration.conferencesaudiobuffercutoff = readconfig("Advanced", "ConferencesAudioBufferCutOff", 250)
                       Configuration.udppacketsize = readconfig("Advanced", "UDPMaxPacketSize", 1480)
-                          Configuration.autologin = load_configuration_boolean("Login", "EnableAutoLogin", true)
+                            Configuration.autologin = load_configuration_boolean("Login", "EnableAutoLogin", true)
+                            greeting = readini(EltenPath.join(Dirs.eltendata, "elten.ini"), "Login", "Greeting", "\0")
+                            Configuration.greeting = (greeting == "\0") ? nil : greeting
                           if lang!=Configuration.language
                             setlocale(Configuration.language)
                             SpeechOutput.apply_current_settings if defined?(SpeechOutput)

--- a/src/eapi/structs.rb
+++ b/src/eapi/structs.rb
@@ -1,4 +1,4 @@
-﻿# A part of Elten - EltenLink / Elten Network desktop client.
+# A part of Elten - EltenLink / Elten Network desktop client.
 # Copyright (C) 2014-2026 Dawid Pieper
 # Elten is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 3. 
 # Elten is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details. 
@@ -49,7 +49,7 @@ module EltenAPI
   end
     module Configuration
       class <<self
-        attr_accessor :listtype, :usepan, :soundcard, :microphone, :controlspresentation, :contextmenubar, :soundthemeactivation, :typingecho, :linewrapping, :hidewindow, :synctime, :registeractivity, :voice, :language, :voicerate, :voicevolume, :soundtheme, :volume, :usefx, :bgsounds, :voicepitch, :usedenoising, :autologin, :autostart, :roundupforms, :checkupdates, :enablebraille, :useechocancellation, :usevoicedictionary, :disablefeednotifications, :maintabs, :showemptynotifications, :mainnotificationfocus, :mainnotificationsort, :mainnotificationtypeorder, :iimodifiers, :iicards, :usebilinearhrtf, :disablehttp2, :tcpconferences, :udppacketsize, :conferencesaudiobuffer , :conferencesaudiobuffercutoff, :disableconferencemiconrecord, :enableaudiobuffering, :saytimeperiod, :saytimetype, :autoplay, :branch, :keyboardscheme, :macoscharacternavigation, :requestresponsecachemode
+        attr_accessor :listtype, :usepan, :soundcard, :microphone, :controlspresentation, :contextmenubar, :soundthemeactivation, :typingecho, :linewrapping, :hidewindow, :synctime, :registeractivity, :voice, :language, :voicerate, :voicevolume, :soundtheme, :volume, :usefx, :bgsounds, :voicepitch, :usedenoising, :autologin, :autostart, :roundupforms, :checkupdates, :enablebraille, :useechocancellation, :usevoicedictionary, :disablefeednotifications, :maintabs, :showemptynotifications, :mainnotificationfocus, :mainnotificationsort, :mainnotificationtypeorder, :iimodifiers, :iicards, :usebilinearhrtf, :disablehttp2, :tcpconferences, :udppacketsize, :conferencesaudiobuffer , :conferencesaudiobuffercutoff, :disableconferencemiconrecord, :enableaudiobuffering, :saytimeperiod, :saytimetype, :autoplay, :branch, :keyboardscheme, :macoscharacternavigation, :requestresponsecachemode, :greeting
         def to_h
           h={}
           instance_variables.each do |v|

--- a/src/scenes/account.rb
+++ b/src/scenes/account.rb
@@ -293,7 +293,6 @@ def load_signs
   setting_category(p_("Account", "Status and signature"))
   make_setting(p_("Account", "Status displayed after your name on all lists of users"), :text, 'status')
   make_setting(p_("Account", "Signature placed below all your forum posts"), :text, 'signature')
-  make_setting(p_("Account", "Greeting read after you log in to Elten"), :text, 'greeting')
 end
 def load_notifications_settings
   setting_category(p_("Account", "Notifications"))

--- a/src/scenes/login.rb
+++ b/src/scenes/login.rb
@@ -236,11 +236,15 @@ if $speech_wait == true
   speech_wait
 end
 play_sound("login")
-if Session.greeting == "" or Session.greeting == "\r\n" or Session.greeting == nil or Session.greeting == " "
-speak(p_("Login", "Logged in as: %{user}")%{:user=>name}) if $silentstart != true
+greeting = Configuration.greeting
+if greeting.nil?
+  greeting = Session.greeting if defined?(Session) && Session.respond_to?(:greeting)
+end
+if greeting.to_s.strip == ""
+  speak(p_("Login", "Logged in as: %{user}")%{:user=>name}) if $silentstart != true
 else
-  speak(Session.greeting) if $silentstart != true
-  end
+  speak(greeting) if $silentstart != true
+end
 EltenAPI::NotificationService.synchronize_runtime_state
 else
   case login_error&.code.to_s

--- a/src/scenes/settings.rb
+++ b/src/scenes/settings.rb
@@ -239,6 +239,10 @@ def make_window
       make_setting(p_("Settings", "Language"), langs, "Interface", "Language", langsmapping)
                             make_setting(p_("Settings", "Automatically minimize Elten Window to system tray"), :bool, "Interface", "HideWindow") if tray_supported?
                                         make_setting(p_("Settings", "Enable auto-login"), :bool, "Login", "EnableAutoLogin")
+        if readini(EltenPath.join(Dirs.eltendata, "elten.ini"), "Login", "Greeting", "\0") == "\0" && defined?(Session) && Session.respond_to?(:greeting) && Session.greeting.to_s.strip != ""
+          setcurrentconfig("Login", "Greeting", Session.greeting)
+        end
+        make_setting(p_("Account", "Greeting read after you log in to Elten"), :text, "Login", "Greeting")
         make_setting(
           p_("Settings", "Start Elten after I log on to Windows"),
           [p_("Settings", "Do not start automatically"), p_("Settings", "Start hidden"), p_("Settings", "Start with the window visible")],


### PR DESCRIPTION
### Description

This PR moves the login greeting setting (*"Greeting read after you log in to Elten"*) from the remote account profile (`Scene_Account`) to the desktop client application settings (`Scene_Settings` -> *General* -> `Login.Greeting` in `elten.ini`).

As discussed in forum topic #27657, the login greeting is a desktop-specific voice synthesizer announcement that is not utilized on mobile platforms (e.g. Eltenger on iOS/Android). Keeping it in the account profile caused mobile clients to unnecessarily expose an unused field, whereas desktop users need it as a local client preference.

### Summary of Changes

1. **`src/scenes/account.rb`**:
   - Removed `make_setting(p_("Account", "Greeting read after you log in to Elten"), :text, 'greeting')` from `load_signs`.
   - The account settings now strictly manage account status and signature without submitting `greeting` to the server.

2. **`src/scenes/settings.rb`**:
   - Added the greeting setting to the *General* category (`load_general`), placed right under *Enable auto-login* (`Login.EnableAutoLogin`).
   - Uses `p_("Account", "Greeting read after you log in to Elten")` to preserve existing translations without requiring changes to translation files.
   - **Migration & Continuity**: If `Login.Greeting` has not yet been set in `elten.ini`, the field is automatically prefilled with `Session.greeting` from the user's active session, preventing loss of customized greetings.

3. **`src/eapi/structs.rb` & `src/eapi/core/configuration.rb`**:
   - Added `:greeting` accessor to `EltenAPI::Configuration`.
   - `load_configuration` loads `Login.Greeting` from `elten.ini`, preserving `nil` when the key is absent to allow fallback.

4. **`src/scenes/login.rb`**:
   - Prioritizes `Configuration.greeting`, falling back to `Session.greeting` if not yet configured in local settings.

### Verification

- [x] Tested syntax and Ruby instruction compilation via `RubyVM::InstructionSequence.compile` (all 5 files passed).
- [x] Verified UTF-8 encoding without BOM.
- [x] Hot-reloaded into a live running Elten 3 instance via MCP tools.
- [x] Confirmed the setting appears in *Program settings -> General* prefilled with the user's greeting.
- [x] Confirmed the setting is removed from *Account -> Status and signature*.
- [x] Confirmed that `Scene_WelcomeWizard` is unaffected (it only uses `:feed_greeting` for feed posts).