### PR TITLE
Add conference moderation keyboard shortcuts and unban confirmation

### DIFF
--- a/src/scenes/conference.rb
+++ b/src/scenes/conference.rb
@@ -163,6 +163,21 @@ end
         Conference.kick(user.id)
         }
       end
+      if Conference.channel.administrators.include?(Session.name) && (Conference.channel.groupid==0 || Conference.channel.groupid==nil) && user.name != Session.name
+        menu.option(p_("Conference", "Ban user"), nil, "b") {
+          confirm(p_("Conference", "Are you sure you want to ban %{user}?") % { user: user.name }) do
+            Conference.ban(user.name)
+          end
+          @form.focus
+        }
+        if !(Conference.channel.whitelist || []).include?(user.name)
+          menu.option(p_("Conference", "Add to whitelist"), nil, "l") {
+            Conference.whitelist(user.name)
+            play_sound("listbox_select")
+            @form.focus
+          }
+        end
+      end
       if Conference.channel.administrators.include?(Session.name)
         if user.supervisor==nil || user.supervisor==0
                 menu.option(p_("Conference", "Take over this user's stream")) {
@@ -1390,7 +1405,7 @@ card=cards[cardid] if cardid>0
 if Conference.channel.id!=0
   menu.submenu(p_("Conference", "Channel")) {|m|
   if Conference.channel.groupid==0 || Conference.channel.groupid==nil
-  m.option(p_("Conference", "Show banned users")) {
+  m.option(p_("Conference", "Show banned users"), nil, "B") {
   showbanned
   @form.focus
   }
@@ -1401,7 +1416,7 @@ if Conference.channel.id!=0
   }
   if Conference.channel.administrators.include?(Session.name)
     if Conference.channel.groupid==0 || Conference.channel.groupid==nil
-  m.option(p_("Conference", "Show channel whitelist"), nil, "l") {
+  m.option(p_("Conference", "Show channel whitelist"), nil, "L") {
   showwhitelist
   @form.focus
   }
@@ -1429,11 +1444,18 @@ def showbanned
   lst_banned.bind_context{|menu|
   if banned.size>0
     menu.useroption(banned[lst_banned.index])
-    menu.option(p_("Conference", "Unban"), nil, :del) {
-    Conference.unban(banned[lst_banned.index])
-    refr.call
-        lst_banned.focus
-    }
+    if Conference.channel.administrators.include?(Session.name) && (Conference.channel.groupid==0 || Conference.channel.groupid==nil)
+      menu.option(p_("Conference", "Unban"), nil, :del) {
+        user = banned[lst_banned.index]
+        if user != nil
+          confirm(p_("Conference", "Are you sure you want to unban %{user}?") % { user: user }) do
+            Conference.unban(user)
+            refr.call
+          end
+          lst_banned.focus
+        end
+      }
+    end
   end
   if Conference.channel.administrators.include?(Session.name) && (Conference.channel.groupid==0 || Conference.channel.groupid==nil)
   menu.option(p_("Conference", "Ban user"), nil, "n") {


### PR DESCRIPTION
### Description

This PR introduces dedicated keyboard shortcuts and moderation improvements in conferences (`Scene_Conference`), as requested and discussed in beta-testing forum thread #16137 (*[Zmiana] [Konferencje] skrut lista zbanowanych*).

Previously, managing banned users and whitelists required traversing multi-level menus during live voice conferences, which was slow when moderating a channel. Furthermore, unbanning a user with the Delete key in the banned list executed immediately without confirmation, posing a risk of accidental unbans.

### Summary of Changes

1. **Channel Menu Shortcuts ([`src/scenes/conference.rb`](src/scenes/conference.rb))**:
   - Assigned **`Ctrl+Shift+B`** (`"B"`) to *Show banned users* (`showbanned`) in the channel submenu.
   - Updated *Show channel whitelist* (`showwhitelist`) to **`Ctrl+Shift+L`** (`"L"`) in the channel submenu (previously `Ctrl+L`).

2. **Channel Users Context Menu ([`src/scenes/conference.rb`](src/scenes/conference.rb))**:
   - Added **`Ctrl+B`** (`"b"`) to ban the currently selected user from the channel (*Ban user*), guarded with a confirmation dialogue (`confirm`), channel administrator check, non-group channel validation, and protection against banning oneself.
   - Added **`Ctrl+L`** (`"l"`) to add the currently selected user to the channel whitelist (*Add to whitelist*), available for channel administrators in non-group channels when the user is not yet on the whitelist.

3. **Confirmation on Unban ([`src/scenes/conference.rb`](src/scenes/conference.rb))**:
   - Wrapped the Delete (`:del`) / *Unban* action in the banned list (`showbanned`) with a confirmation prompt (`confirm(p_("Conference", "Are you sure you want to unban %{user}?"))`) and restricted it to channel administrators in non-group channels, matching the whitelist dialogue pattern.

4. **Standards & Localisation**:
   - Reused existing Gettext translation strings where possible (`p_("Conference", "Ban user")`, `p_("Conference", "Add to whitelist")`).
   - Clean UTF-8 encoding without BOM.
   - Preserved `locale/elten.pot` and `.po` files untouched in accordance with the Contributing Guide.

### Verification Performed

- [x] Verified Ruby syntax via `RubyVM::InstructionSequence.compile` (`bom: false`, `syntax: OK`).
- [x] Verified shortcut keycode mappings in Elten (`"B"` -> `Ctrl+Shift+B`, `"L"` -> `Ctrl+Shift+L`, `"b"` -> `Ctrl+B`, `"l"` -> `Ctrl+L`).
- [x] Hot-reloaded and verified interactions live in a running Elten 3 client during real voice channel moderation testing.
- [x] Confirmed confirmation dialogues on both ban and unban actions prevent accidental execution.