### PR TITLE
Fix NameError when managing blog coworkers and deleting blogs

### DIFF
--- a/src/eltenlink/blog.rb
+++ b/src/eltenlink/blog.rb
@@ -197,6 +197,7 @@ module EltenLink
 
       def delete_blog(client, blog:)
         client.api_data("DELETE", "/api/v1/blogs/#{blog.to_s.urlenc}")
+        clear_owners_cache
         true
       end
 
@@ -367,6 +368,11 @@ module EltenLink
         result = $blogowners[blog]
         result = [blog] if result == nil && Users.exists?(client, blog)
         result || []
+      end
+
+      def clear_owners_cache
+        $blogownerstime = 0
+        $blogowners = nil
       end
 
       private


### PR DESCRIPTION
### Description

This PR fixes a critical `NameError` crash (`undefined local variable or method 'clear_owners_cache' for module EltenLink::Blog`) that occurred whenever a user attempted to leave, add, or remove blog coworkers, as reported in beta-testing forum thread #28074 (*[Błąd] [Blogi] Nie można opuścić współprowadzonego bloga*).

### Problem Analysis

In `src/eltenlink/blog.rb`, methods `add_coworker` (line 182), `remove_coworker` (line 188), and `leave_coworkers` (line 194) execute their respective API requests against the EltenLink server and then attempt to call `clear_owners_cache`. However, `clear_owners_cache` was never defined in `EltenLink::Blog`. Consequently, any coworker operation immediately threw:
```
NameError: undefined local variable or method 'clear_owners_cache' for module EltenLink::Blog
```
Furthermore, `delete_blog` in `src/eltenlink/blog.rb` did not clear the local blog owners cache upon deleting a blog.

### Summary of Changes

1. **Define `clear_owners_cache` in `EltenLink::Blog` (`src/eltenlink/blog.rb`)**:
   - Defined `def clear_owners_cache` inside `EltenLink::Blog` to reset `$blogownerstime = 0` and `$blogowners = nil`.
   - Subsequent calls to `EltenLink::Blog.owners` re-fetch fresh owner data from the server.
2. **Clear Cache on Blog Deletion (`src/eltenlink/blog.rb`)**:
   - Added `clear_owners_cache` to `delete_blog` to ensure deleted blogs do not retain stale cached owner information.
3. **Standards & Localisation**:
   - Clean UTF-8 encoding without BOM.
   - Preserved `locale/elten.pot` and `.po` files untouched in accordance with the Contributing Guide.

### Verification Performed

- [x] Verified Ruby syntax compilation via `RubyVM::InstructionSequence.compile`.
- [x] Verified method definition and cache resetting in test simulation:
  - `EltenLink::Blog.respond_to?(:clear_owners_cache)` returns `true`.
  - Calling `clear_owners_cache` resets `$blogownerstime` to `0` and `$blogowners` to `nil`.
  - Calling `owners` after `clear_owners_cache` re-queries `/api/v1/blogs/owners` and caches fresh data.
- [x] Verified coworker workflows:
  - `add_coworker`, `remove_coworker`, and `leave_coworkers` execute successfully without raising `NameError`.
  - Verified live in a running Elten 3 client during real-world testing (co-authored blog successfully left without error).