### PR TITLE
Fix blog mention confirmation speech

### DIFF
--- a/src/scenes/blog.rb
+++ b/src/scenes/blog.rb
@@ -506,8 +506,8 @@ else
             rescue EltenLink::Error
               alert(_("Error"))
             else
-              alert(np_("Blog", "The mention has been sent.", "The mentions have been sent.", selections.size))
               @sel.focus
+              alert(np_("Blog", "The mention has been sent.", "The mentions have been sent.", selections.size))
               break
             end
           end
@@ -906,8 +906,8 @@ def context(menu)
         rescue EltenLink::Error
           alert(_("Error"))
         else
-          alert(np_("Blog", "The mention has been sent.", "The mentions have been sent.", selections.size))
           @form.focus
+          alert(np_("Blog", "The mention has been sent.", "The mentions have been sent.", selections.size))
           break
         end
       end


### PR DESCRIPTION
Summary:
- restore focus before announcing successful blog mentions
- prevent NVDA from cutting off the confirmation after sending an empty-message mention

Testing:
- compiled src/scenes/blog.rb with RubyVM
- git diff --check