### PR TITLE
Display technical program installation errors in a text window with backtrace

### DIFF
--- a/src/scenes/programs.rb
+++ b/src/scenes/programs.rb
@@ -588,7 +588,7 @@ when 1
          setlocale(Configuration.language)
          true
        elsif install_error!=nil
-         alert(program_install_error_message(install_error)) if ask
+         show_program_install_error(install_error) if ask
          false
        else
          alert(p_("Programs", "Installation cancelled.")) if ask && cancelled
@@ -622,7 +622,7 @@ when 1
          info=Programs.setup_package_info(file)
        rescue Exception => e
          Log.warning("Program package read failed: #{e.class}: #{e.message}")
-         alert(program_install_error_message(e))
+         show_program_install_error(e)
          return
        end
        confirm(install_details(info[:manifest], format_size(info[:size]), File.basename(file))) {
@@ -648,7 +648,7 @@ when 1
          setlocale(Configuration.language)
          @refresh=true
        elsif install_error!=nil
-         alert(program_install_error_message(install_error))
+         show_program_install_error(install_error)
        else
          alert(p_("Programs", "Installation cancelled."))
        end
@@ -669,6 +669,39 @@ when 1
        lines.push(p_("Programs", "Package: %{file}")%{:file=>package_file.to_s}) if package_file!=nil && package_file.to_s!=""
        lines.push(p_("Programs", "Size: %{size}")%{:size=>size.to_s})
        lines.join("\n")
+     end
+
+     def show_program_install_error(error)
+       message = program_install_error_message(error)
+       if simple_program_install_error?(error)
+         alert(message)
+       else
+         details = message.to_s.dup
+         trace = if Programs.respond_to?(:clean_program_backtrace)
+           Programs.clean_program_backtrace(error)
+         else
+           Array(error.respond_to?(:backtrace) ? error.backtrace : nil)
+         end
+         if trace.empty? && error.respond_to?(:cause) && error.cause
+           trace = if Programs.respond_to?(:clean_program_backtrace)
+             Programs.clean_program_backtrace(error.cause)
+           else
+             Array(error.cause.respond_to?(:backtrace) ? error.cause.backtrace : nil)
+           end
+         end
+         if trace.size > 0
+           details += "\n\n#{p_("Program", "Backtrace:")}\n#{trace.join("\n")}"
+         end
+         display_text(details, header: _("Error"))
+       end
+     end
+
+     def simple_program_install_error?(error)
+       program_install_error_cause(error, Programs::UnsupportedAPIVersionError) != nil ||
+         program_install_error_cause(error, Programs::UnsupportedEltenLinkContractError) != nil ||
+         program_install_error_cause(error, Programs::UnsupportedPlatformError) != nil ||
+         program_install_error_cause(error, Programs::ProgramSigning::VerificationUnavailableError) != nil ||
+         program_install_error_cause(error, Programs::ProgramSigning::MissingSignatureError) != nil
      end
 
      def program_install_error_message(error)


### PR DESCRIPTION
### Summary

When a program fails to install due to a technical error (such as a Ruby syntax error, archive extraction failure, file I/O error, or other unhandled exceptions), Elten previously displayed a modal `alert` dialog. Because `alert` only speaks the message once and dismisses immediately upon pressing Enter/Escape without allowing text selection or cursor movement, screen reader users could not review line numbers, file paths, or copy the error details to send to the developer.

This pull request improves error reporting during program installation:
- Differentiates between simple user-facing validation errors and technical exceptions.
- Keeps the quick, convenient `alert` dialog for standard validation errors (`UnsupportedAPIVersionError`, `UnsupportedEltenLinkContractError`, `UnsupportedPlatformError`, `VerificationUnavailableError`, `MissingSignatureError`).
- Displays technical failures, syntax errors, and exceptions in a multi-line, read-only text window (`display_text`) with a cleaned `Backtrace:`, allowing arrow-key navigation and copying via `Ctrl+C`.
- Preserves existing Gettext translation strings (`_("Error")`, `p_("Program", "Backtrace:")`) without modifying `locale/` files, in accordance with the contributing guidelines.

### Changes

- `src/scenes/programs.rb`:
  - Added `show_program_install_error` and `simple_program_install_error?`.
  - Routed errors in `install_remote_program`, `install_from_file`, and `install_package_file` through `show_program_install_error`.

### Verification

- Verified syntax and encoding using RubyVM compilation (UTF-8 without BOM).
- Verified that simple validation errors (`UnsupportedAPIVersionError`, `MissingSignatureError`) continue to open standard `alert` dialogs.
- Verified that technical errors (`SyntaxError`, `RuntimeError`) with backtraces format the message and call stack into `display_text`.